### PR TITLE
Support prims in the interpreter

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -154,3 +154,33 @@ fn zmain(zarg) {
 
 
 ]
+
+{ #category : #tests }
+JibInterpreterTests >> test_05 [
+	| program main interpreter |
+	program := JibParser parse:'
+
+val zsign_extend = "sign_extend" : (%bv, %i) ->  %bv	
+
+val zmain : (%bv16) ->  %bv32
+
+fn zmain(zarg) {
+  zz1 : %bv32;
+  zz1 = zsign_extend(zarg, 16);
+  return = zz1;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal simplify = (-1 toBitVector: 32).
+
+
+
+]

--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -125,6 +125,31 @@ fn zmain() {
 
 	self assert: interpreter retVal = 16r2A.
 	self assert:(interpreter getRegister: 'zPC') = 16r2A.
+]
+
+{ #category : #tests }
+JibInterpreterTests >> test_04 [
+	| program main interpreter |
+	program := JibParser parse:'
+val zmain : (%bool) ->  %bool
+
+fn zmain(zarg) {
+  zz1 : %bool;
+  zz1 = @neq(zarg, false);
+  zz1 = @not(zarg);
+  return = zz1;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { true toBool }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal = false.
 
 
 

--- a/src/Sail-Jib-Interpreter/Exp_Bool.extension.st
+++ b/src/Sail-Jib-Interpreter/Exp_Bool.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #'Exp_Bool' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Exp_Bool >> interpretIn: interpreter [
+	^ interpreter interpretBool: self
+]

--- a/src/Sail-Jib-Interpreter/Exp_Call.extension.st
+++ b/src/Sail-Jib-Interpreter/Exp_Call.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #'Exp_Call' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Exp_Call >> interpretIn: interpreter [
+	^ interpreter interpretCallOp: self
+]

--- a/src/Sail-Jib-Interpreter/Exp_I64.extension.st
+++ b/src/Sail-Jib-Interpreter/Exp_I64.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #'Exp_I64' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Exp_I64 >> interpretIn: interpreter [
+	^ interpreter interpretI64: self
+]

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -91,6 +91,12 @@ JibInterpreter >> interpretBits: expr [
 
 ]
 
+{ #category : #'interpreting - exprs' }
+JibInterpreter >> interpretBool: expr [
+	^ expr value
+
+]
+
 { #category : #'interpreting - insns' }
 JibInterpreter >> interpretCall: insn [
 	| args fn |

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -163,6 +163,12 @@ JibInterpreter >> interpretGoto: insn [
 ]
 
 { #category : #'interpreting - exprs' }
+JibInterpreter >> interpretI64: expr [
+	^ expr value
+
+]
+
+{ #category : #'interpreting - exprs' }
 JibInterpreter >> interpretId: expr [
 	^ self get: expr id
 

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -108,6 +108,19 @@ JibInterpreter >> interpretCall: insn [
 
 ]
 
+{ #category : #'interpreting - exprs' }
+JibInterpreter >> interpretCallOp: expr [
+	"This is called #interpretCallOp: and not #interpretCall: since the
+	 latter is already used for Instr_Call."
+
+	| args |
+
+	args := expr argExprs collect:[:argExpr | argExpr interpretIn: self ].
+	^expr op evaluateWithArguments: args.
+
+
+]
+
 { #category : #'interpreting - insns' }
 JibInterpreter >> interpretCopy: insn [
 	| val loc |

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -99,10 +99,19 @@ JibInterpreter >> interpretBool: expr [
 
 { #category : #'interpreting - insns' }
 JibInterpreter >> interpretCall: insn [
-	| args fn |
+	| args func |
 
 	args := insn argExprs collect:[:expr | expr interpretIn: self ].
-	context := JibInterpreterContext for: insn function arguments: args caller: context.
+	func := insn function.
+	
+	func isExtern ifTrue:[
+		| retv |
+		
+		retv := func extern evaluateWithArguments: args.
+		insn location assign: retv in: self.		
+	] ifFalse:[	
+		context := JibInterpreterContext for: insn function arguments: args caller: context.
+	].
 
 
 

--- a/src/Sail-Jib/Def_Extern.class.st
+++ b/src/Sail-Jib/Def_Extern.class.st
@@ -24,6 +24,16 @@ Def_Extern class >> inducedParser [
 	)
 ]
 
+{ #category : #accessing }
+Def_Extern >> extern [
+	^JibExtern named: ext
+]
+
+{ #category : #testing }
+Def_Extern >> isExtern [
+	^true
+]
+
 { #category : #printing }
 Def_Extern >> printOn: aStream [
 	aStream nextPut: (Character codePoint: 16r2197).

--- a/src/Sail-Jib/Exp_Bool.class.st
+++ b/src/Sail-Jib/Exp_Bool.class.st
@@ -18,3 +18,8 @@ Exp_Bool class >> inducedParser [
 Exp_Bool >> childrenDo: aBlock [
 	"Leaf node, nothing to do."
 ]
+
+{ #category : #accessing }
+Exp_Bool >> value [
+	^b
+]

--- a/src/Sail-Jib/Exp_Call.class.st
+++ b/src/Sail-Jib/Exp_Call.class.st
@@ -17,7 +17,6 @@ Exp_Call class >> inducedParser [
 
 { #category : #enumerating }
 Exp_Call >> childrenDo: aBlock [
-	aBlock value: op.
 	args do: aBlock
 	
 ]

--- a/src/Sail-Jib/Exp_Call.class.st
+++ b/src/Sail-Jib/Exp_Call.class.st
@@ -15,10 +15,20 @@ Exp_Call class >> inducedParser [
 	construct: #(op args)
 ]
 
+{ #category : #accessing }
+Exp_Call >> argExprs [
+	^ args
+]
+
 { #category : #enumerating }
 Exp_Call >> childrenDo: aBlock [
 	args do: aBlock
 	
+]
+
+{ #category : #accessing }
+Exp_Call >> op [
+	^ op
 ]
 
 { #category : #enumerating }

--- a/src/Sail-Jib/Exp_I64.class.st
+++ b/src/Sail-Jib/Exp_I64.class.st
@@ -18,3 +18,8 @@ Exp_I64 class >> inducedParser [
 Exp_I64 >> childrenDo: aBlock [
 	"Leaf node, nothing to do."
 ]
+
+{ #category : #accessing }
+Exp_I64 >> value [
+	^ v
+]

--- a/src/Sail-Jib/Extern_sign_extend.class.st
+++ b/src/Sail-Jib/Extern_sign_extend.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #'Extern_sign_extend',
+	#superclass : #JibExtern,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+Extern_sign_extend class >> id [
+	^ 'sign_extend'" : %bv , %i -> %bv "
+]
+
+{ #category : #evaluating }
+Extern_sign_extend >> evaluateWithArguments: args [
+	^ args first signExtend: args second
+]

--- a/src/Sail-Jib/JibDef.class.st
+++ b/src/Sail-Jib/JibDef.class.st
@@ -33,6 +33,11 @@ JibDef class >> isAbstract [
 ]
 
 { #category : #testing }
+JibDef >> isExtern [
+	^false
+]
+
+{ #category : #testing }
 JibDef >> isFn [
 	^false
 ]

--- a/src/Sail-Jib/JibExtern.class.st
+++ b/src/Sail-Jib/JibExtern.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : #JibExtern,
+	#superclass : #JibPrim,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #testing }
+JibExtern class >> isAbstract [
+	^self == JibExtern 
+]
+
+{ #category : #accessing }
+JibExtern class >> named: id [
+	self allSubclassesDo: [ :cls |
+		(cls isAbstract not and:[ cls id = id ]) ifTrue:[
+			^cls new
+		]
+	].
+	self error: 'No extern named ''' , id , ''''.
+	
+	"
+	JibExtern named: 'sign_extend'
+	"
+]
+
+{ #category : #testing }
+JibExtern >> isExtern [
+	^ true
+]

--- a/src/Sail-Jib/JibOp.class.st
+++ b/src/Sail-Jib/JibOp.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #JibOp,
-	#superclass : #JibProgramNode,
+	#superclass : #JibPrim,
 	#classInstVars : [
 		'uniqueInstance'
 	],
@@ -8,12 +8,30 @@ Class {
 }
 
 { #category : #parsing }
+JibOp class >> asParser [
+	^PPChoiceParser withAll: (self subclasses collect:#inducedParser)
+	
+	"
+	JibOp asParser plus parse: '@not @neq'
+	"
+]
+
+{ #category : #parsing }
 JibOp class >> inducedParser [
-	^ Op_Neq asParser
-	/ Op_Not asParser
+	self assert: self isAbstract not.
+	
+	^self id asParser trimRight ==> [ :_ | self new ].
 ]
 
 { #category : #testing }
 JibOp class >> isAbstract [
 	^self == JibOp
+]
+
+{ #category : #parsing }
+JibOp class >> signature [
+	"Return this prim's signature (as a synthetic instance of `Def_Val`).
+	 This is needed for type unification."
+	
+	^ self subclassResponsibility 
 ]

--- a/src/Sail-Jib/JibPrim.class.st
+++ b/src/Sail-Jib/JibPrim.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #JibPrim,
+	#superclass : #Object,
+	#instVars : [
+		'signature'
+	],
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+JibPrim class >> id [
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+JibPrim class >> isAbstract [
+	^self == JibPrim
+]
+
+{ #category : #accessing }
+JibPrim class >> signature [
+	"Return this primt's signature (as fabricated instance of `Def_Val`).
+	 This is needed for type unification."
+
+	^ self subclassResponsibility
+
+
+
+]
+
+{ #category : #evaluating }
+JibPrim >> evaluateWithArguments: args [
+	^ self subclassResponsibility 
+]
+
+{ #category : #accessing }
+JibPrim >> id [
+	"Return the name (id) of this prim.
+
+	 Do not override this method, override class-side #id!"
+
+	^self class id
+]
+
+{ #category : #testing }
+JibPrim >> isExtern [
+	^ false
+]
+
+{ #category : #accessing }
+JibPrim >> signature [
+	"Return this prim's signature (as fabricated instance of `Def_Val`).
+
+	 Do not override this method, override class-side #signature!"
+
+	signature isNil ifTrue:[
+		signature := self class signature
+	].
+	^signature
+]

--- a/src/Sail-Jib/JibProgram.class.st
+++ b/src/Sail-Jib/JibProgram.class.st
@@ -28,15 +28,13 @@ JibProgram >> functionSignaturesDo: aBlock [
 
 { #category : #enumerating }
 JibProgram >> functionsDo: aBlock [
-	defs do: [ :def | def isFn ifTrue:[ aBlock value: def ] ]
-	
+	defs do: [ :def | (def isFn or:[def isExtern]) ifTrue:[ aBlock value: def ] ]
 ]
 
 { #category : #lookup }
 JibProgram >> lookupFunction: id [
 	self functionsDo: [ :fn | fn id = id ifTrue:[ ^fn ] ].
 	self error:'No ''fn'' named ''' , id , ''''.
-
 ]
 
 { #category : #lookup }

--- a/src/Sail-Jib/Op_Neq.class.st
+++ b/src/Sail-Jib/Op_Neq.class.st
@@ -4,8 +4,12 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Op_Neq class >> inducedParser [
-	^ '@neq' asParser
-	==> [ :_ | self new ]
+{ #category : #accessing }
+Op_Neq class >> id [
+	^ '@neq'
+]
+
+{ #category : #evaluating }
+Op_Neq >> evaluateWithArguments: args [
+	^ args first ~= args second
 ]

--- a/src/Sail-Jib/Op_Not.class.st
+++ b/src/Sail-Jib/Op_Not.class.st
@@ -4,8 +4,12 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Op_Not class >> inducedParser [
-	^ '@not' asParser
-	==> [ :_ | self new ]
+{ #category : #accessing }
+Op_Not class >> id [
+	^ '@not'
+]
+
+{ #category : #evaluating }
+Op_Not >> evaluateWithArguments: args [
+	^ args first not
 ]


### PR DESCRIPTION
This PR adds basic support for "primitives" in the interpreter, that is, Ops (`@not` and so on) and externs (`val zsail_sign_extend = "sign_extend" : (%bv, %i) ->  %bv`)