### PR TITLE
Fix parsing to parse `riscv64.ir`

### DIFF
--- a/src/Sail-Jib-Parsing/JibParser.class.st
+++ b/src/Sail-Jib-Parsing/JibParser.class.st
@@ -49,6 +49,7 @@ JibParser >> exp [
 	/ exp_string	
 	/ exp_unit
 	""
+	/ exp_ref
 	/ exp_id
 	
 	

--- a/src/Sail-Jib-Parsing/JibParser.class.st
+++ b/src/Sail-Jib-Parsing/JibParser.class.st
@@ -1,12 +1,221 @@
 Class {
 	#name : #JibParser,
 	#superclass : #PPCompositeParser,
+	#instVars : [
+		'exp',
+		'id',
+		'exp_field',
+		'exp_kind',
+		'exp_struct',
+		'exp_unwrap',
+		'exp_id',
+		'exp_unwrap_in_field',
+		'exp_field_in_kind',
+		'exp_field_in_unwrap',
+		'exp_bits',
+		'exp_bool',
+		'exp_call',
+		'exp_i128',
+		'exp_i64',
+		'exp_string',
+		'exp_unit',
+		'exp_field_in_unwrap_in_field',
+		'exp_ref'
+	],
 	#category : #'Sail-Jib-Parsing'
 }
 
 { #category : #accessing }
 JibParser class >> id [
 	^(#letter asParser, (#word asParser / $_ asParser) star) flatten
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp [
+	^ exp_field_in_unwrap_in_field
+	/ exp_field_in_unwrap
+	/ exp_field_in_kind
+	/ exp_field
+	/ exp_kind
+	/ exp_unwrap_in_field
+	/ exp_unwrap
+	/ exp_struct
+	""
+	/ exp_bits
+	/ exp_bool
+	/ exp_call
+	/ exp_i128
+	/ exp_i64	
+	/ exp_string	
+	/ exp_unit
+	""
+	/ exp_id
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_bits [
+	| hex bin |
+
+	hex := (('0x' asParser / '#x' asParser) , #hex asParser plus flatten) ==> #second.
+
+	bin := (('0b' asParser / '#b' asParser) , ($0 asParser / $1 asParser) plus flatten) ==> #second.
+
+
+	^ ('bitzero' asParser ==> [ :_ | 0 toBitVector: 1 ])
+	/	('bitone'  asParser ==> [ :_ | 1 toBitVector: 1 ]) 
+	/	('emptybitvec' asParser ==> [ :_ | BitVector empty ]) 
+	/	(hex ==>  [ :str | (Integer readFrom: str base: 16) toBitVector: str size * 4]) 
+	/	(bin ==>  [ :str | (Integer readFrom: str base: 2) toBitVector: str size ])
+		==> [:x| Exp_Bits constructNewFrom: { x } accordingTo: #(x) ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_bool [
+	^ ('true'  asParser ==> [ :_ | Bool true ])
+	/ ('false'  asParser ==> [ :_ | Bool false ]) 
+		==> [:x| Exp_Bool constructNewFrom: { x } accordingTo: #(b) ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_call [
+	^ JibOp asParser , exp commaList
+		==> [ :x | Exp_Call constructNewFrom: x accordingTo: #(op args) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_field [
+	^ (exp_struct / exp_id) , $. asParser , id 
+		==> [ :x | Exp_Field constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_field_in_kind [
+	"Synthetic, to avoid left recursion in grammar"
+
+	^ exp_field , 'is' asParser trim, id 
+		==> [ :x | Exp_Kind constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_field_in_unwrap [
+	^ exp_field , 'as' asParser trim, id 
+		==> [ :x | Exp_Unwrap constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_field_in_unwrap_in_field [
+	^ (exp_field_in_unwrap) , $. asParser , id 
+		==> [ :x | Exp_Field constructNewFrom: x accordingTo: #(exp - id) ]	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_i128 [
+	^ PPParser decimalInteger , $: asParser trim , 'i128' asParser trim
+		==> [:v| Exp_I128 constructNewFrom: { v } accordingTo: #(v - -) ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_i64 [
+	^ PPParser decimalInteger , ($: asParser trim , 'i64' asParser trim) optional
+		==> [:v| Exp_I64 constructNewFrom: v accordingTo: #(v -) ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_id [
+	^ JibParser id ==> [ :x | Exp_Id constructNewFrom: { x } accordingTo: #(id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_kind [
+	^ (exp_struct / exp_id) , 'is' asParser trim, id 
+		==> [ :x | Exp_Kind constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_ref [
+	^ '&' asParser trim, JibParser id ==> [ :x | Exp_Ref constructNewFrom: x accordingTo: #(- id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_string [
+	^ PPParser doubleQuoted 
+		==> [:x| Exp_String constructNewFrom: { x } accordingTo: #(s) ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_struct [
+	| fexp |
+	
+	fexp := (id , $= asParser trim , exp asParser)
+					==> [ :x | x first -> x third ].
+
+	^ 'struct' asParser trim , id trim , fexp commaSeparated braces
+		==> [ :x | Exp_Struct constructNewFrom: x accordingTo: #(- id fields) ]
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_unit [
+	^ '()' asParser 
+		==> [ :_ | Exp_Unit new ]
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_unwrap [
+	^ (exp_struct / exp_id) , 'as' asParser trim, id 
+		==> [ :x | Exp_Unwrap constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - exp' }
+JibParser >> exp_unwrap_in_field [
+	"Synthetic, to avoid left recursion in grammar"
+	
+	^ (exp_unwrap) , $. asParser , id 
+		==> [ :x | Exp_Field constructNewFrom: x accordingTo: #(exp - id) ]
+	
+	
+	
+]
+
+{ #category : #'rules - helpers' }
+JibParser >> id [
+	^ self class id
 ]
 
 { #category : #accessing }

--- a/src/Sail-Jib-Tests/JibParsingTest.class.st
+++ b/src/Sail-Jib-Tests/JibParsingTest.class.st
@@ -167,6 +167,25 @@ JibParsingTest >> test_UnknownUnique [
 ]
 
 { #category : #'tests - individual defs' }
+JibParsingTest >> test_let [
+	| val |
+	val := defParser parse: '
+let (zdefault_meta: %unit) {
+  zz40 : %unit `8 15:30-15:32;
+  zz40 = () `8 15:30-15:32;
+  zdefault_meta = zz40 `8 15:4-15:16;
+}
+
+val zmain : () -> %unit
+
+fn zmain() { 
+  return =();
+  end;
+}
+'.
+	self assert: (val isKindOf: Def_Let).
+]
+
 JibParsingTest >> test_struct [
 	| struct |
 	struct := defParser parse: 'struct ztuplez3z5bv12_z5bv5_z5bv5_z5enumz0zziop {

--- a/src/Sail-Jib-Tests/JibParsingTest.class.st
+++ b/src/Sail-Jib-Tests/JibParsingTest.class.st
@@ -166,6 +166,147 @@ JibParsingTest >> test_UnknownUnique [
 	self assert: (val isKindOf: SourceLoc_UnknownUnique)
 ]
 
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_field_of_id [
+	| src val |
+	
+	src := 'zmergez3var.ztuplez3z5bv12_z5bv5_z5bv5_z5enumz0zziop3'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Field).
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Id).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_field_of_struct [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzArchitecture_z5bv4 {ztuplez3z5enumz0zzArchitecture_z5bv40 = za, ztuplez3z5enumz0zzArchitecture_z5bv41 = zm}.ztuplez3z5enumz0zzArchitecture_z5bv41'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Field).
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Struct).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_field_of_unwrap [
+	| src val |
+	
+	src := 'zmergez3var as zITYPE.ztuplez3z5bv12_z5bv5_z5bv5_z5enumz0zziop3'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Field).
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Unwrap).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_field_of_unwrap_of_field_of_struct [
+	| src val |
+	
+	src := 'struct A {B = zt, C = zz40}.D as E.F'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Field).
+	
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Unwrap).
+	
+	self assert: (val children first children size == 1).
+	self assert: (val children first children first isKindOf: Exp_Field).
+	
+	self assert: (val children first children first children size == 1).
+	self assert: (val children first children first children first isKindOf: Exp_Struct).
+
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_id [
+	| src val |
+	
+	src := 'ztuplez3z5enumz0zzArchitecture_z5bv4'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Id).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_kind_of_field [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result {ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result0 = zcur_priv, ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 = zctl}.ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 is zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Kind).
+	
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Field).
+	
+	self assert: (val children first children size == 1).
+	self assert: (val children first children first isKindOf: Exp_Struct).
+	
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_kind_of_id [
+	| src val |
+	
+	src := 'ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 is zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Kind).
+	
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Id).
+	
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_kind_of_struct [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result {ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result0 = zcur_priv, ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 = zctl} is zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Kind).
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Struct).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
 { #category : #'tests - individual defs' }
 JibParsingTest >> test_let [
 	| val |
@@ -186,6 +327,21 @@ fn zmain() {
 	self assert: (val isKindOf: Def_Let).
 ]
 
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_ref [
+	| src val |
+	
+	src := '&zmergez3var'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Ref).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - individual defs' }
 JibParsingTest >> test_struct [
 	| struct |
 	struct := defParser parse: 'struct ztuplez3z5bv12_z5bv5_z5bv5_z5enumz0zziop {
@@ -195,6 +351,75 @@ JibParsingTest >> test_struct [
   ztuplez3z5bv12_z5bv5_z5bv5_z5enumz0zziop3: %enum ziop
 }'.
 	self assert: (struct isKindOf: Def_Struct)
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_struct_e [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzArchitecture_z5bv4 {ztuplez3z5enumz0zzArchitecture_z5bv40 = za, ztuplez3z5enumz0zzArchitecture_z5bv41 = zm}'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Struct).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_unwrap_of_field [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result {ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result0 = zcur_priv, ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 = zctl}.ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 as zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Unwrap).
+	
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Field).
+	
+	self assert: (val children first children size == 1).
+	self assert: (val children first children first isKindOf: Exp_Struct).
+	
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_unwrap_of_id [
+	| src val |
+	
+	src := 'ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 as zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Unwrap).
+	
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Id).
+	
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
+]
+
+{ #category : #'tests - expressions' }
+JibParsingTest >> test_unwrap_of_struct [
+	| src val |
+	
+	src := 'struct ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result {ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result0 = zcur_priv, ztuplez3z5enumz0zzPrivilege_z5unionz0zzctl_result1 = zctl} as zCTL_TRAP'.
+	
+	val := JibExp asParser end parse: src.
+	self assert: (val isKindOf: Exp_Unwrap).
+	self assert: (val children size == 1).
+	self assert: (val children first isKindOf: Exp_Struct).
+	
+	"
+	src copyFrom: val position to: (val position + 100 min: src size)
+	"
 ]
 
 { #category : #'tests - individual defs' }

--- a/src/Sail-Jib/Def_Let.class.st
+++ b/src/Sail-Jib/Def_Let.class.st
@@ -1,10 +1,36 @@
 Class {
 	#name : #'Def_Let',
 	#superclass : #JibDef,
+	#instVars : [
+		'ids',
+		'instrs'
+	],
 	#category : #'Sail-Jib'
 }
 
 { #category : #syntax }
 Def_Let class >> inducedParser [
-	^'let' asParser "BOGUS, completely!"
+	"
+	'let' '(' <ids:Comma<Arg>> ')' '{' <instrs:Semi<Instr>> '}' =>
+        Def::Let(ids, instrs),
+	"
+	| arg |
+	
+	arg := JibParser id, $: asParser trim, Ty asParser ==> [ :x | x first -> x last ].
+	
+	^ 'let' asParser trim
+	, (arg trim commaList ==> [ :x|x ifNil:#() ])
+	, (JibInstr asParser, $; asParser trim ==> #first) star braces
+	construct: #(- ids instrs)
+]
+
+{ #category : #enumerating }
+Def_Let >> childrenDo: aBlock [
+	ids do:[:arg | aBlock value: arg value].
+	instrs do: aBlock
+]
+
+{ #category : #accessing }
+Def_Let >> instrs [
+	^instrs
 ]

--- a/src/Sail-Jib/Exp_Bits.class.st
+++ b/src/Sail-Jib/Exp_Bits.class.st
@@ -7,35 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Bits class >> inducedParser [
-	"
-	See https://github.com/rems-project/isla/blob/master/isla-lib/src/bitvector.rs#L97
-	"
-	| hex bin |
-
-	hex := (('0x' asParser / '#x' asParser) , #hex asParser plus flatten) ==> #second.
-
-	bin := (('0b' asParser / '#b' asParser) , ($0 asParser / $1 asParser) plus flatten) ==> #second.
-
-
-	^ (PPSequenceParser with:
-		('bitzero' asParser ==> [ :_ | 0 toBitVector: 1 ]) /
-		('bitone'  asParser ==> [ :_ | 1 toBitVector: 1 ]) /
-		('emptybitvec' asParser ==> [ :_ | BitVector empty ]) /
-		(hex ==>  [ :str | (Integer readFrom: str base: 16) toBitVector: str size * 4]) /
-		(bin ==>  [ :str | (Integer readFrom: str base: 2) toBitVector: str size ])
-	) construct: #(x)
-
-
-	"
-	Exp_Bits inducedParser parse:'0xAB'
-	Exp_Bits inducedParser parse:'#b01'
-	Exp_Bits inducedParser parse:'bitone'
-	Exp_Bits inducedParser parse:'emptybitvec'
-	"
-]
-
 { #category : #enumerating }
 Exp_Bits >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Bool.class.st
+++ b/src/Sail-Jib/Exp_Bool.class.st
@@ -7,13 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Bool class >> inducedParser [
-	^ (PPSequenceParser with: 'true'  asParser ==> [ :_ | Bool true  ])
-	/ (PPSequenceParser with: 'false' asParser ==> [ :_ | Bool false ])
-	construct: #(b)
-]
-
 { #category : #enumerating }
 Exp_Bool >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Call.class.st
+++ b/src/Sail-Jib/Exp_Call.class.st
@@ -8,13 +8,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Call class >> inducedParser [
-	^ JibOp asParser
-	, JibExp asParser commaList
-	construct: #(op args)
-]
-
 { #category : #accessing }
 Exp_Call >> argExprs [
 	^ args

--- a/src/Sail-Jib/Exp_Field.class.st
+++ b/src/Sail-Jib/Exp_Field.class.st
@@ -8,14 +8,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Field class >> inducedParser [
-	^ (Exp_Unwrap asParser / Exp_Id asParser) "BOGUS: this should be Exp; however, this leads to recursion on the left"
-	, $. asParser
-	, JibParser id
-	construct: #(exp - id)
-]
-
 { #category : #enumerating }
 Exp_Field >> childrenDo: aBlock [
 	aBlock value: exp

--- a/src/Sail-Jib/Exp_I128.class.st
+++ b/src/Sail-Jib/Exp_I128.class.st
@@ -7,14 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_I128 class >> inducedParser [
-	^ PPParser decimalInteger
-	, $: asParser trim
-	, 'i128' asParser trim
-	construct: #(v - -)
-]
-
 { #category : #enumerating }
 Exp_I128 >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_I64.class.st
+++ b/src/Sail-Jib/Exp_I64.class.st
@@ -7,13 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_I64 class >> inducedParser [
-	^ PPParser decimalInteger
-	, ($: asParser trim, 'i64' asParser trim) optional
-	construct: #(v -)
-]
-
 { #category : #enumerating }
 Exp_I64 >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Id.class.st
+++ b/src/Sail-Jib/Exp_Id.class.st
@@ -7,16 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Id class >> inducedParser [
-	^ (PPSequenceParser with: JibParser id)
-	construct: #(id)
-	
-"
-JibExp inducedParser parse: 'xyz'
-"
-]
-
 { #category : #enumerating }
 Exp_Id >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Kind.class.st
+++ b/src/Sail-Jib/Exp_Kind.class.st
@@ -8,14 +8,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Kind class >> inducedParser [
-	^ Exp_Id asParser trim "BOGUS: this should be Exp; however, this leads to recursion on the left"
-	, 'is' asParser trim
-	, JibParser id
-	construct: #(exp - id)
-]
-
 { #category : #enumerating }
 Exp_Kind >> childrenDo: aBlock [
 	aBlock value: exp

--- a/src/Sail-Jib/Exp_Ref.class.st
+++ b/src/Sail-Jib/Exp_Ref.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #'Exp_Ref',
+	#superclass : #JibExp,
+	#instVars : [
+		'id'
+	],
+	#category : #'Sail-Jib'
+}
+
+{ #category : #enumerating }
+Exp_Ref >> childrenDo: aBlock [
+	"Leaf node, nothing to do"
+
+]

--- a/src/Sail-Jib/Exp_String.class.st
+++ b/src/Sail-Jib/Exp_String.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_String class >> inducedParser [
-	^ (PPSequenceParser with: PPParser doubleQuoted)
-	construct: #(s)
-]
-
 { #category : #enumerating }
 Exp_String >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Struct.class.st
+++ b/src/Sail-Jib/Exp_Struct.class.st
@@ -8,26 +8,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Struct class >> Fexp [
-	^ JibParser id trim
-	, $= asParser trim
-	, JibExp asParser
-]
-
-{ #category : #syntax }
-Exp_Struct class >> inducedParser [
-	| fexp |
-	
-	fexp := (JibParser id , $= asParser trim , JibExp asParser)
-					==> [ :x | x first -> x third ].
-
-	^ 'struct' asParser trim
-	, JibParser id trim
-	, fexp commaSeparated braces
-	construct: #(- id fields)
-]
-
 { #category : #enumerating }
 Exp_Struct >> childrenDo: aBlock [
 	fields do:[:field | aBlock value: field value ] 

--- a/src/Sail-Jib/Exp_Unit.class.st
+++ b/src/Sail-Jib/Exp_Unit.class.st
@@ -4,11 +4,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Unit class >> inducedParser [
-	^ '()'  asParser ==> [ :_ | Exp_Unit new ]
-]
-
 { #category : #enumerating }
 Exp_Unit >> childrenDo: aBlock [
 	"Leaf node, nothing to do."

--- a/src/Sail-Jib/Exp_Unwrap.class.st
+++ b/src/Sail-Jib/Exp_Unwrap.class.st
@@ -8,14 +8,6 @@ Class {
 	#category : #'Sail-Jib'
 }
 
-{ #category : #syntax }
-Exp_Unwrap class >> inducedParser [
-	^ Exp_Id asParser trim "BOGUS: this should be Exp; however, this leads to recursion on the left"
-	, 'as' asParser trim
-	, JibParser id trim
-	construct: #(exp - id)
-]
-
 { #category : #enumerating }
 Exp_Unwrap >> childrenDo: aBlock [
 	aBlock value: exp

--- a/src/Sail-Jib/Instr_Arbitrary.class.st
+++ b/src/Sail-Jib/Instr_Arbitrary.class.st
@@ -6,5 +6,5 @@ Class {
 
 { #category : #syntax }
 Instr_Arbitrary class >> inducedParser [
-	^'arbitrary' asParser
+	^'arbitrary' asParser ==> [:_ | self new ]
 ]

--- a/src/Sail-Jib/JibExp.class.st
+++ b/src/Sail-Jib/JibExp.class.st
@@ -5,22 +5,28 @@ Class {
 }
 
 { #category : #parsing }
+JibExp class >> asParser [
+	"
+	Expressions are parsed traditionally, using JibParser.
+	"
+	^ JibParser new productionAt: #exp
+
+	"
+	JibExp asParser end parse:'xyz'
+	JibExp asParser end parse:'xyz.foo'
+	Exp_Field asParser end parse:'xyz.foo'
+	"
+
+
+
+]
+
+{ #category : #parsing }
 JibExp class >> inducedParser [
-	^	Exp_Field asParser
-	/	Exp_Kind asParser
-	/	Exp_Unwrap asParser
-
-
-	/	Exp_Bits asParser
-	/	Exp_Bool asParser
-	/	Exp_I128 asParser
-	/	Exp_I64 asParser
-	/	Exp_String asParser
-	/	Exp_Struct asParser
-	/	Exp_Unit asParser
-	/	Exp_Id asParser
-	/	Exp_Call asParser
-
+	"
+	Expressions are parsed traditionally, using JibParser.
+	"
+	self shouldNotImplement 
 
 
 

--- a/src/Sail-Jib/JibOp.class.st
+++ b/src/Sail-Jib/JibOp.class.st
@@ -16,6 +16,35 @@ JibOp class >> asParser [
 	"
 ]
 
+{ #category : #utilities }
+JibOp class >> create: id [
+	"Create new JibOp class for given `id`"
+
+	| clsName cls |
+
+	self assert: id first == $@.
+
+	clsName := ('Op_', (id copyFrom: 2 to: id size) capitalized) asSymbol.
+	(Smalltalk includesKey: clsName) ifTrue:[ ^self ].
+
+	cls := JibOp subclass: clsName instanceVariableNames: '' classVariableNames: '' package: self package name asString.
+	cls class compile: 'id
+	^ ''' , id , '''' classified: #accessing.
+
+	cls class compile: 'signature
+	^ self shouldBeImplemented' classified: #accessing.
+
+
+	cls compile: 'evaluateWithArguments: args
+	^ self shouldBeImplemented' classified: #evaluating.
+
+	"
+	JibOp create: '@gt'
+	"
+
+
+]
+
 { #category : #parsing }
 JibOp class >> inducedParser [
 	self assert: self isAbstract not.

--- a/src/Sail-Jib/JibOp.class.st
+++ b/src/Sail-Jib/JibOp.class.st
@@ -27,11 +27,3 @@ JibOp class >> inducedParser [
 JibOp class >> isAbstract [
 	^self == JibOp
 ]
-
-{ #category : #parsing }
-JibOp class >> signature [
-	"Return this prim's signature (as a synthetic instance of `Def_Val`).
-	 This is needed for type unification."
-	
-	^ self subclassResponsibility 
-]

--- a/src/Sail-Jib/Op_Gt.class.st
+++ b/src/Sail-Jib/Op_Gt.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #'Op_Gt',
+	#superclass : #JibOp,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+Op_Gt class >> id [
+	^ '@gt'
+]
+
+{ #category : #accessing }
+Op_Gt class >> signature [
+	^ self shouldBeImplemented
+]
+
+{ #category : #evaluating }
+Op_Gt >> evaluateWithArguments: args [
+	^ args first > args second
+]

--- a/src/Sail-Jib/Op_Iadd.class.st
+++ b/src/Sail-Jib/Op_Iadd.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #'Op_Iadd',
+	#superclass : #JibOp,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+Op_Iadd class >> id [
+	^ '@iadd'
+]
+
+{ #category : #accessing }
+Op_Iadd class >> signature [
+	^ self shouldBeImplemented
+]
+
+{ #category : #evaluating }
+Op_Iadd >> evaluateWithArguments: args [
+	^ args first + args second
+]

--- a/src/Sail-Jib/Op_Isub.class.st
+++ b/src/Sail-Jib/Op_Isub.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #'Op_Isub',
+	#superclass : #JibOp,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+Op_Isub class >> id [
+	^ '@isub'
+]
+
+{ #category : #accessing }
+Op_Isub class >> signature [
+	^ self shouldBeImplemented
+]
+
+{ #category : #evaluating }
+Op_Isub >> evaluateWithArguments: args [
+	^ args first - args second
+]

--- a/src/Sail-Jib/Op_Lt.class.st
+++ b/src/Sail-Jib/Op_Lt.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #'Op_Lt',
+	#superclass : #JibOp,
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+Op_Lt class >> id [
+	^ '@lt'
+]
+
+{ #category : #accessing }
+Op_Lt class >> signature [
+	^ self shouldBeImplemented
+]
+
+{ #category : #evaluating }
+Op_Lt >> evaluateWithArguments: args [
+	^ args first < args second
+]


### PR DESCRIPTION
This PR fixes parsing logic to parse full RV64 spec.

This required overhaul of expression parsing to eliminate left recursion in required cases, see 4e5eef1