### PR TITLE
Add support for initializers in interpreter

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
@@ -103,3 +103,55 @@ fn zmain(zarg) {
 
 
 ]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_03 [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+
+let (zxlen_val: %i64) {
+  zz40 : %i64;
+  zz40 = 64;
+  zxlen_val = zz40;
+}
+
+register zPC : %bv64 {
+	zPC = 0xCAFE0000CAFE0000;
+}
+
+val zmain : () -> %i64
+
+fn zmain() {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: #().
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function isRegister.
+	session stepInto: interpreter context. "zz40 : %i64;"
+	session stepInto: interpreter context. "zz40 = 64;"
+	session stepInto: interpreter context. "zxlen_val = zz40;"
+
+	self assert: interpreter context function isLet.
+
+
+
+
+
+
+
+
+
+
+
+]

--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -184,3 +184,67 @@ fn zmain(zarg) {
 
 
 ]
+
+{ #category : #tests }
+JibInterpreterTests >> test_06l [
+	| program main interpreter |
+	program := JibParser parse:'
+
+let (zxlen_val: %i64) {
+  zz40 : %i64;
+  zz40 = 64;
+  zxlen_val = zz40;
+}
+
+val zmain : () -> %i64
+
+fn zmain(zarg) {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal  = 64.
+
+
+
+]
+
+{ #category : #tests }
+JibInterpreterTests >> test_06r [
+	| program main interpreter |
+	program := JibParser parse:'
+
+register zxlen_val : %i64 {
+  zz40 : %i64;
+  zz40 = 64;
+  zxlen_val = zz40;
+}
+
+val zmain : () -> %i64
+
+fn zmain(zarg) {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal  = 64.
+
+
+
+]

--- a/src/Sail-Jib-Interpreter/Def_Fn.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Fn.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #'Def_Fn' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Fn >> hasCode [
+	^ true
+]
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Fn >> instrAt: pc [
+	^instrs at: pc
+]

--- a/src/Sail-Jib-Interpreter/Def_Let.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Let.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #'Def_Let' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Let >> hasCode [
+	^ self hasInitializer
+]
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Let >> hasInitializer [
+	^ instrs notEmpty
+]

--- a/src/Sail-Jib-Interpreter/Def_Register.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Register.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #'Def_Register' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Register >> hasCode [
+	^ self hasInitializer
+]
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Def_Register >> hasInitializer [
+	^ instrs notEmpty
+]

--- a/src/Sail-Jib-Interpreter/JibDebugger.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebugger.class.st
@@ -16,7 +16,7 @@ JibDebugger >> formatInstruction: insn forContext: context [
 
 { #category : #formatting }
 JibDebugger >> formatStackForContext: context [
-	^context function id
+	^context function displayString
 ]
 
 { #category : #'building presentations' }

--- a/src/Sail-Jib-Interpreter/JibDef.extension.st
+++ b/src/Sail-Jib-Interpreter/JibDef.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #JibDef }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+JibDef >> hasCode [
+	^ false
+]

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -4,8 +4,11 @@ Class {
 	#instVars : [
 		'program',
 		'context',
+		'lets',
 		'registers',
-		'retval'
+		'entry',
+		'retval',
+		'todo'
 	],
 	#category : #'Sail-Jib-Interpreter-Interpreter'
 }
@@ -24,14 +27,23 @@ JibInterpreter >> context [
 
 { #category : #'accessing - variables' }
 JibInterpreter >> get: id [
-	(registers includesKey: id) ifTrue:[
+	(lets includesKey: id) ifTrue:[
+		^ lets at: id
+	] ifFalse:[(registers includesKey: id) ifTrue:[
 		^ registers at: id
 	] ifFalse:[
 		^ context get: id
-	]
+	]]
 ]
 
-{ #category : #'accessing - registers' }
+{ #category : #'accessing - globals' }
+JibInterpreter >> getGlobal: id [
+	self assert:(lets includesKey: id).
+
+	^ lets at: id
+]
+
+{ #category : #'accessing - globals' }
 JibInterpreter >> getRegister: id [
 	self assert:(registers includesKey: id).
 
@@ -40,16 +52,33 @@ JibInterpreter >> getRegister: id [
 
 { #category : #initialization }
 JibInterpreter >> initializeWithFunction: fn arguments: args [
+	entry := fn.
 	program := fn program.
-	context := JibInterpreterContext for: fn arguments: args.
 	registers := OrderedDictionary new.
+	lets := OrderedDictionary new.
+	todo := OrderedCollection new.
+
 	program registersDo: [ :register |
-		register instrs notEmpty ifTrue:[
-			self notYetImplemented
+		registers at: register id put: register regType newUndefined.
+
+		register hasInitializer ifTrue:[
+			todo add: (JibInterpreterContext for: register arguments: #())
+		]
+	].
+
+	program letsDo: [ :let |
+		let variables do: [ :nameAndType |
+			lets at: nameAndType key put: nameAndType value newUndefined.
 		].
 
-		registers at: register id put: register regType newUndefined
-	]
+		let hasInitializer ifTrue:[
+			todo add: (JibInterpreterContext for: let arguments: #())
+		]
+	].
+
+	todo add: (JibInterpreterContext for: fn arguments: args).
+
+	context := todo removeFirst.
 
 
 ]
@@ -66,8 +95,6 @@ JibInterpreter >> interpret1 [
 	"Interpret exactly one instruction."
 	| instr |
 
-	self assert: (context pc between: 1 and: context function instrs size).
-
 	instr := context function instrs at: context pc.
 	"Here we advance pc to following instruction. However, the pc
 	 can be changed as part of interpreting that instruction (for
@@ -76,6 +103,17 @@ JibInterpreter >> interpret1 [
 	 instructions. Maybe not a great idea, will see."
 	context pc: context pc + 1.
 	instr interpretIn: self.
+
+	(context notNil and:[context function isFn not]) ifTrue:[
+		"For some unknown reason, let and register initializers do not
+		 have an 'end' instruction. So here we check if PC is past the
+		 instruction sequence of current initilalizer and if so, finish
+		 its execution by interpreting fabricated Instr_End (this is
+		 merely a trick to have function return logic at one place)."
+		(context pc) == (context function instrs size + 1) ifTrue:[
+			self interpretEnd: Instr_End new.
+		].
+	].
 ]
 
 { #category : #'interpreting - insns' }
@@ -158,10 +196,13 @@ JibInterpreter >> interpretEnd: insn [
 	"Drop the current context"
 	context := caller.
 
-
 	caller isNil ifTrue:[
-		"We're done, just note the resulting value."
-		retval := callee getRetVal.
+		todo isEmpty ifTrue:[
+			"We're done, just note the resulting value."
+			retval := callee getRetVal.
+		] ifFalse:[
+			context := todo removeFirst.
+		]
 	] ifFalse:[
 		| call |
 
@@ -226,14 +267,23 @@ JibInterpreter >> retVal [
 
 { #category : #'accessing - variables' }
 JibInterpreter >> set: id to: value [
-	(registers includesKey: id) ifTrue:[
+	(lets includesKey: id) ifTrue:[
+		lets at: id put: value.
+	] ifFalse:[(registers includesKey: id) ifTrue:[
 		registers at: id put: value.
 	] ifFalse:[
 		context set: id to: value
-	]
+	]]
 ]
 
-{ #category : #'accessing - registers' }
+{ #category : #'accessing - globals' }
+JibInterpreter >> setGlobal: id to: value [
+	self assert:(lets includesKey: id).
+
+	lets at: id put: value
+]
+
+{ #category : #'accessing - globals' }
 JibInterpreter >> setRegister: id to: value [
 	self assert:(registers includesKey: id).
 

--- a/src/Sail-Jib-Interpreter/JibInterpreterContext.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreterContext.class.st
@@ -11,13 +11,20 @@ Class {
 }
 
 { #category : #'instance creation' }
-JibInterpreterContext class >> for: fn arguments: args [
-	^self for: fn arguments: args caller: nil
+JibInterpreterContext class >> for: code [
+	self assert: (code isRegister or:[code isLet]).
+
+	^self for: code arguments: #()
 ]
 
 { #category : #'instance creation' }
-JibInterpreterContext class >> for: fn arguments: args caller: caller [
-	^self basicNew initializeWithFunction: fn arguments: args caller: caller
+JibInterpreterContext class >> for: code arguments: args [
+	^self for: code arguments: args caller: nil
+]
+
+{ #category : #'instance creation' }
+JibInterpreterContext class >> for: code arguments: args caller: caller [
+	^self basicNew initializeWith: code arguments: args caller: caller
 ]
 
 { #category : #accessing }
@@ -68,20 +75,26 @@ JibInterpreterContext >> gtLocalsIn: composite [
 ]
 
 { #category : #initialization }
-JibInterpreterContext >> initializeWithFunction: fn arguments: args caller: callr [
-	| signature |
-
-	self assert: (fn isKindOf: Def_Fn).
+JibInterpreterContext >> initializeWith: code arguments: args caller: callr [
+	self assert: code hasCode.
 
 	values := OrderedDictionary new.
-	function := fn.
+	function := code.
 	caller := callr.
 	pc := 1.
 
-	signature := function signature.
-	values at: function retName put: signature retType newUndefined.
-	function argNames with: args do:[:argName :argValue  |
-		values at: argName put: argValue.
+	function isFn ifTrue:[
+		"Initialize arguments and return value. We do this only
+		 for real functions (Def_Fn) since let and register initializers
+		 do not take arguments and have no return value"
+
+		| signature |
+
+		signature := function signature.
+		values at: function retName put: signature retType newUndefined.
+		function argNames with: args do:[:argName :argValue  |
+			values at: argName put: argValue.
+		].
 	].
 
 
@@ -96,7 +109,11 @@ JibInterpreterContext >> pc [
 
 { #category : #accessing }
 JibInterpreterContext >> pc: anInteger [
-	self assert: (pc between: 1 and: function instrs size).
+	"Set the current PC (index into instrs sequence) in this context.
+	 Here we allow to set the PC one beyond the size of an instruction
+	 sequence - this is to signal end of initializer execution. See
+	 JibInterpreter >> interpret1."
+	self assert: (pc between: 1 and: function instrs size + 1).
 
 	pc := anInteger
 ]

--- a/src/Sail-Jib/Def_Let.class.st
+++ b/src/Sail-Jib/Def_Let.class.st
@@ -30,7 +30,24 @@ Def_Let >> childrenDo: aBlock [
 	instrs do: aBlock
 ]
 
+{ #category : #printing }
+Def_Let >> displayStringOn: aStream [
+	aStream nextPutAll: 'let '.
+	ids do:[:nameAndType | aStream nextPutAll: nameAndType key zdecode ]
+		  separatedBy:[aStream nextPutAll: ', ']
+]
+
 { #category : #accessing }
 Def_Let >> instrs [
 	^instrs
+]
+
+{ #category : #testing }
+Def_Let >> isLet [
+	^ true
+]
+
+{ #category : #accessing }
+Def_Let >> variables [
+	^ ids
 ]

--- a/src/Sail-Jib/Def_Register.class.st
+++ b/src/Sail-Jib/Def_Register.class.st
@@ -28,6 +28,13 @@ Def_Register >> childrenDo: aBlock [
 	
 ]
 
+{ #category : #printing }
+Def_Register >> displayStringOn: aStream [
+	aStream nextPutAll: 'register '.
+	aStream nextPutAll: id zdecode.
+
+]
+
 { #category : #accessing }
 Def_Register >> id [
 	^ id
@@ -35,7 +42,7 @@ Def_Register >> id [
 
 { #category : #accessing }
 Def_Register >> instrs [
-	^instrs
+	^ instrs
 ]
 
 { #category : #testing }
@@ -54,4 +61,5 @@ Def_Register >> printOn: aStream [
 { #category : #accessing }
 Def_Register >> regType [
 	^ ty
+
 ]

--- a/src/Sail-Jib/JibDef.class.st
+++ b/src/Sail-Jib/JibDef.class.st
@@ -43,6 +43,11 @@ JibDef >> isFn [
 ]
 
 { #category : #testing }
+JibDef >> isLet [
+	^ false
+]
+
+{ #category : #testing }
 JibDef >> isRegister [
 	^false
 ]

--- a/src/Sail-Jib/JibProgram.class.st
+++ b/src/Sail-Jib/JibProgram.class.st
@@ -31,6 +31,12 @@ JibProgram >> functionsDo: aBlock [
 	defs do: [ :def | (def isFn or:[def isExtern]) ifTrue:[ aBlock value: def ] ]
 ]
 
+{ #category : #enumerating }
+JibProgram >> letsDo: aBlock [
+	defs do: [ :def | def isLet ifTrue:[ aBlock value: def ] ]
+
+]
+
 { #category : #lookup }
 JibProgram >> lookupFunction: id [
 	self functionsDo: [ :fn | fn id = id ifTrue:[ ^fn ] ].


### PR DESCRIPTION
This PR depends on #7 (for parsing `let` and `register` initializers). 