### PR TITLE
Add support for breakpoints in interpreter

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
@@ -91,17 +91,99 @@ fn zmain(zarg) {
 
 	session stepInto: interpreter context. "end"
 	self assert: (interpreter context isNil).
+]
 
+{ #category : #tests }
+JibDebuggerSessionTests >> test_04a [
+	| program main interpreter session |
 
+	program := JibParser parse:'
+val zf : (%bv32) ->  %bv32
 
+fn zf(zarg) {
+  zz39 : %bv32 `1;
+  zz39 = 0b00000000000000000000000000101010 `2;
+  return = zz39 `3;
+  end;
+}
 
+val zmain : (%bv32) ->  %bv32
 
+fn zmain(zarg) {
+  zz1 : %bv32 `1;
+  zz1 = zf(zarg) `2;
+  return = zz1 `3;
+  end;
+}
 
+'.
 
+	main := program lookupFunction: 'zmain'.
 
+	interpreter := JibInterpreter for: main arguments: { 0 toBitVector: 32 }.
+	session := JibDebuggerSession for: interpreter.
 
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function id = 'zmain'.
+	session stepOver: interpreter context. "zz1 : %bv32 `1;"
+	session stepOver: interpreter context. "zz1 = zf(zarg) `2;"
 
+	self assert: interpreter context function id = 'zmain'.
+	self assert: interpreter context pc = 3.
 
+	session stepOver: interpreter context. "return = zz1 `3"
+	self assert: (interpreter context get: 'return') = 42.
+
+	session stepOver: interpreter context. "end"
+	self assert: (interpreter context isNil).
+]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_04b [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+val zf : (%bv32) ->  %bv32
+
+fn zf(zarg) {
+  zz39 : %bv32 `1;
+  zz39 = 0b00000000000000000000000000101010 `2;
+  return = zz39 `3;
+  end;
+}
+
+val zmain : (%bv32) ->  %bv32
+
+fn zmain(zarg) {
+  zz1 : %bv32 `1;
+  zz1 = zf(zarg) `2;
+  return = zz1 `3;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { 0 toBitVector: 32 }.
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function id = 'zmain'.
+	session stepInto: interpreter context. "zz1 : %bv32 `1;"
+	session stepInto: interpreter context. "zz1 = zf(zarg) `2;"
+
+	self assert: interpreter context function id = 'zf'.
+	self assert: interpreter context pc = 1.
+	
+	session stepOver: interpreter context caller. "return = zz1 `3;"
+
+	self assert: interpreter context function id = 'zmain'.
+	self assert: interpreter context pc = 3.
 ]
 
 { #category : #tests }

--- a/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
@@ -155,7 +155,41 @@ JibDebuggerSession >> stepInto: context [
 
 { #category : #'debugging actions' }
 JibDebuggerSession >> stepOver: context [
-	self notYetImplemented
+	"If we're step-over in current (top-most) context, first
+	 execute a single instruction. This instruction must be executed
+	 anyway (step-over executes at least one instruction) and as a
+	 sideefect, a PC gets updated to the PC of next instruction.
+	 This is important, see below."
+	
+	context == interpreter context ifTrue:[
+		self step.
+	].
+	
+	"
+	 Now, if the current (top-most) context is not the context 
+	 in which we should step-over (either never was, or the instruction
+	 stepped above was a call), then we arrange a temporary breakpoint
+	 right after the call instruction and continue until this (or some other)
+	 breakpoint hits.
+	
+	 Also: the `self step` above may have executed entry point's `end` 
+	 instruction in which case interpreter terminates (there's no more 
+	 instructions to execute). Hence the below notNil guard."	
+	interpreter context notNil ifTrue:[
+		context ~~ interpreter context ifTrue:[
+			| instr break |
+				
+			instr := context function instrs at: context pc. 
+			break := JibInterpreterBreakpoint at: instr.
+			break temporary: true.
+	
+			interpreter addBreakpoint: break.
+		
+			self cont.
+		].
+	].
+	self triggerEvent: #stepOver 
+	
 ]
 
 { #category : #'debugging actions' }

--- a/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
@@ -13,7 +13,7 @@ JibDebuggerSession class >> debuggingActionsForPragma: aSymbol for: aDebugger [
 		"ResumeDebugAction ."
 		"RestartDebugAction ."
 		StepIntoDebugAction .
-		"StepOverDebugAction ."
+		StepOverDebugAction .
 	} inject: OrderedCollection new
 		into: [ :currentActions :aClass |
 			currentActions
@@ -69,6 +69,17 @@ JibDebuggerSession >> clear [
 	interpreter := nil.
 ]
 
+{ #category : #private }
+JibDebuggerSession >> cont [
+	"Continue until a breakpoint is hit or intepreter terminates."
+
+	[
+		interpreter interpret
+	] on: JibInterpreterBreakpointHitNotification do: [ :hit |
+		"Stop"
+	].
+]
+
 { #category : #initialization }
 JibDebuggerSession >> initializeWithInterpreter: aJibInterpreter [
 	self assert: (aJibInterpreter isKindOf: JibInterpreter).
@@ -109,12 +120,34 @@ JibDebuggerSession >> stack [
 	^stack
 ]
 
+{ #category : #private }
+JibDebuggerSession >> step [
+	"Execute exactly one instruction."
+
+	interpreter interpret1
+]
+
 { #category : #'debugging actions' }
 JibDebuggerSession >> stepInto: context [
 	context == interpreter context ifTrue:[
-		interpreter interpret1.
+		"If we're stepping in top-most context, just
+		 execute one instruction and stop."
+		self step.
 	] ifFalse:[
-		self notYetImplemented
+		"If we're stepping in any other context, 'step-into' means
+		 'step to next instruction in this context'. So we setup a
+		 temporary breakpoint on that instruction and continue until
+		 this (or some other) breakpoint hits."
+
+		| instr break |
+
+		instr := context function instrs at: context pc.
+		break := JibInterpreterBreakpoint at: instr.
+		break temporary: true.
+
+		interpreter addBreakpoint: break.
+
+		self cont.
 	].
 
 	self triggerEvent: #stepInto

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -8,7 +8,8 @@ Class {
 		'registers',
 		'entry',
 		'retval',
-		'todo'
+		'todo',
+		'breakpoints'
 	],
 	#category : #'Sail-Jib-Interpreter-Interpreter'
 }
@@ -16,6 +17,21 @@ Class {
 { #category : #'tests - instance' }
 JibInterpreter class >> for: fn arguments: args [
 	^self basicNew initializeWithFunction: fn arguments: args
+]
+
+{ #category : #'adding & removing breakpoints' }
+JibInterpreter >> addBreakpoint: aJibInterpreterBreakpoint [
+	self assert: aJibInterpreterBreakpoint instr program == program.
+	self assert:(breakpoints includesKey: aJibInterpreterBreakpoint instr) not.
+	
+	breakpoints at: aJibInterpreterBreakpoint instr put: aJibInterpreterBreakpoint
+	
+ 
+]
+
+{ #category : #accessing }
+JibInterpreter >> breakpoints [
+	^ breakpoints 
 ]
 
 { #category : #accessing }
@@ -57,6 +73,7 @@ JibInterpreter >> initializeWithFunction: fn arguments: args [
 	registers := OrderedDictionary new.
 	lets := OrderedDictionary new.
 	todo := OrderedCollection new.
+	breakpoints := IdentityDictionary new.
 
 	program registersDo: [ :register |
 		registers at: register id put: register regType newUndefined.
@@ -93,9 +110,16 @@ JibInterpreter >> interpret [
 { #category : #interpreting }
 JibInterpreter >> interpret1 [
 	"Interpret exactly one instruction."
-	| instr |
+	| instr breakpoint |
 
 	instr := context function instrs at: context pc.
+	
+	"Check for breakpoint."
+	breakpoint := breakpoints at: instr ifAbsent:[nil].
+	breakpoint notNil ifTrue:[				
+		breakpoint stopIn: self.
+	].
+	
 	"Here we advance pc to following instruction. However, the pc
 	 can be changed as part of interpreting that instruction (for
 	 example to implement jumps). This is done here eagerly so one
@@ -258,6 +282,16 @@ JibInterpreter >> interpretUntil: condition [
 	condition whileTrue:[
 		self interpret1.
 	]
+]
+
+{ #category : #'adding & removing breakpoints' }
+JibInterpreter >> removeBreakpoint: aJibInterpreterBreakpoint [
+	self assert: aJibInterpreterBreakpoint instr program == program.
+	self assert:(breakpoints includesKey: aJibInterpreterBreakpoint instr).
+	
+	breakpoints removeKey: aJibInterpreterBreakpoint instr
+	
+ 
 ]
 
 { #category : #accessing }

--- a/src/Sail-Jib-Interpreter/JibInterpreterBreakpoint.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreterBreakpoint.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #JibInterpreterBreakpoint,
+	#superclass : #Object,
+	#instVars : [
+		'instr',
+		'temporary'
+	],
+	#category : #'Sail-Jib-Interpreter-Interpreter'
+}
+
+{ #category : #'instance creation' }
+JibInterpreterBreakpoint class >> at: aJibInstr [
+	^self basicNew initializeWithInstruction: aJibInstr 
+
+]
+
+{ #category : #initialization }
+JibInterpreterBreakpoint >> initializeWithInstruction: i [
+	instr := i.
+	temporary := false.
+]
+
+{ #category : #accessing }
+JibInterpreterBreakpoint >> instr [
+	^ instr
+]
+
+{ #category : #processing }
+JibInterpreterBreakpoint >> stopIn: interpreter [
+	"This method is called just before interpeter is about to execute
+	 instruction associated with this breakpoint."
+	
+	temporary ifTrue:[
+		interpreter removeBreakpoint: self.
+	].
+	JibInterpreterBreakpointHitNotification signal
+]
+
+{ #category : #accessing }
+JibInterpreterBreakpoint >> temporary [
+	"Return if this breakpoint is temporary. Temporary breakpoints hit only once -
+	 in other words they're automatically removed once they hit."
+	
+	^ temporary
+]
+
+{ #category : #accessing }
+JibInterpreterBreakpoint >> temporary: aBoolean [
+	temporary := aBoolean
+]

--- a/src/Sail-Jib-Interpreter/JibInterpreterBreakpointHitNotification.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreterBreakpointHitNotification.class.st
@@ -1,0 +1,9 @@
+Class {
+	#name : #JibInterpreterBreakpointHitNotification,
+	#superclass : #Notification,
+	#instVars : [
+		'instr',
+		'temporary'
+	],
+	#category : #'Sail-Jib-Interpreter-Interpreter'
+}

--- a/src/Sail-Jib-Interpreter/JibInterpreterContext.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreterContext.class.st
@@ -118,9 +118,19 @@ JibInterpreterContext >> pc: anInteger [
 	pc := anInteger
 ]
 
+{ #category : #printing }
+JibInterpreterContext >> printOn: aStream [
+	super printOn: aStream.
+	aStream nextPutAll: '(in '.
+	function displayStringOn: aStream.
+	aStream nextPutAll: ' at '.
+	pc printOn: aStream.
+	aStream nextPut: $).
+]
+
 { #category : #'accessing - variables' }
 JibInterpreterContext >> set: id to: value [
 	self assert: (values includesKey: id).
-
+	
 	values at: id put: value
 ]


### PR DESCRIPTION
This commit adds crude support for breakpoint in the interpreter and implements 
"step-over" and "finish" debug operations using temporary breakpoints.