### PR TITLE
Fix step-into and step-over w.r.t initializers

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
@@ -30,12 +30,6 @@ fn zf(zarg) {
 	session stepInto: interpreter context. "zz39 : %bv32 `1;"
 	session stepInto: interpreter context. "zz39 = 0b00000000000000000000000000101010 `2;"
 	self assert: (interpreter context get: 'zz39') = 42.
-
-
-
-
-
-
 ]
 
 { #category : #tests }
@@ -91,6 +85,94 @@ fn zmain(zarg) {
 
 	session stepInto: interpreter context. "end"
 	self assert: (interpreter context isNil).
+]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_03 [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+
+let (zxlen_val: %i64) {
+  zz40 : %i64;
+  zz40 = 64;
+  zxlen_val = zz40;
+}
+
+register zPC : %bv64 {
+	zPC = 0xCAFE0000CAFE0000;
+}
+
+val zmain : () -> %i64
+
+fn zmain() {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: #().
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function isRegister.
+	session stepInto: interpreter context. "zz40 : %i64;"
+	session stepInto: interpreter context. "zz40 = 64;"
+	session stepInto: interpreter context. "zxlen_val = zz40;"
+
+	self assert: interpreter context function isLet.
+]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_03c [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+
+let (zxlen_val: %i64) {
+  zxlen_val = zf();
+}
+
+val zf : () -> %i64
+
+fn zf() {
+  return = 64;
+  end;
+}
+
+val zmain : () -> %i64
+
+fn zmain() {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: #().
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function isLet.
+	session stepInto: interpreter context. " zxlen_val = zf();"
+
+	self assert: interpreter context function isFn.
+	self assert: interpreter context function id = 'zf'.
+	self assert: interpreter context caller function isLet.
+
+	session stepInto: interpreter context caller.
+
+	self assert: interpreter context function isFn.
+	self assert: interpreter context function id = 'zmain'.
 ]
 
 { #category : #tests }
@@ -179,7 +261,7 @@ fn zmain(zarg) {
 
 	self assert: interpreter context function id = 'zf'.
 	self assert: interpreter context pc = 1.
-	
+
 	session stepOver: interpreter context caller. "return = zz1 `3;"
 
 	self assert: interpreter context function id = 'zmain'.
@@ -187,19 +269,20 @@ fn zmain(zarg) {
 ]
 
 { #category : #tests }
-JibDebuggerSessionTests >> test_03 [
+JibDebuggerSessionTests >> test_04c [
 	| program main interpreter session |
 
 	program := JibParser parse:'
 
 let (zxlen_val: %i64) {
-  zz40 : %i64;
-  zz40 = 64;
-  zxlen_val = zz40;
+  zxlen_val = zf();
 }
 
-register zPC : %bv64 {
-	zPC = 0xCAFE0000CAFE0000;
+val zf : () -> %i64
+
+fn zf() {
+  return = 64;
+  end;
 }
 
 val zmain : () -> %i64
@@ -219,21 +302,15 @@ fn zmain() {
 	"
 	JibDebugger openOn: session.
 	"
-	self assert: interpreter context function isRegister.
-	session stepInto: interpreter context. "zz40 : %i64;"
-	session stepInto: interpreter context. "zz40 = 64;"
-	session stepInto: interpreter context. "zxlen_val = zz40;"
-
 	self assert: interpreter context function isLet.
+	session stepInto: interpreter context. " zxlen_val = zf();"
 
+	self assert: interpreter context function isFn.
+	self assert: interpreter context function id = 'zf'.
+	self assert: interpreter context caller function isLet.
 
+	session stepOver: interpreter context caller.
 
-
-
-
-
-
-
-
-
+	self assert: interpreter context function isFn.
+	self assert: interpreter context function id = 'zmain'.
 ]

--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -248,3 +248,40 @@ fn zmain(zarg) {
 
 
 ]
+
+{ #category : #tests }
+JibInterpreterTests >> test_07 [
+	| program main interpreter |
+	program := JibParser parse:'
+
+let (zxlen_val: %i64) {
+  zxlen_val = zf();
+}
+
+val zf : () -> %i64
+
+fn zf() { 
+  return = 64;
+  end;
+}
+
+val zmain : () -> %i64
+
+fn zmain(zarg) {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal  = 64.
+
+
+
+]

--- a/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
@@ -137,11 +137,23 @@ JibDebuggerSession >> stepInto: context [
 		"If we're stepping in any other context, 'step-into' means
 		 'step to next instruction in this context'. So we setup a
 		 temporary breakpoint on that instruction and continue until
-		 this (or some other) breakpoint hits."
+		 this (or some other) breakpoint hits.
+		
+		 It may happen that context is for initializer and that current 
+		 instruction in that context is a call *and also* a last instruction
+		 of the initializer. In that case, the 'next' instruction is
+		 is the first instruction of next entry in interpreter's todo
+		 (since initializers do not have `end`, see JibInterpreter >> interpret1).
+		"
 
 		| instr break |
-
-		instr := context function instrs at: context pc.
+		
+		(context function isFn not and:[(context pc) == (context function instrs size + 1)]) ifTrue:[
+			instr := interpreter todo first function instrs at: 1.
+		] ifFalse:[
+			instr := context function instrs at: context pc.
+		].
+		
 		break := JibInterpreterBreakpoint at: instr.
 		break temporary: true.
 
@@ -161,33 +173,63 @@ JibDebuggerSession >> stepOver: context [
 	 sideefect, a PC gets updated to the PC of next instruction.
 	 This is important, see below."
 	
-	context == interpreter context ifTrue:[
+	interpreter context == context ifTrue:[
 		self step.
+
+		"If the instruction we just executed was the very last instruction
+		 of main (i.e, 'end' instruction of `entry` function), then interpreter's
+	 	 context will be `nil` and we're done."
+		interpreter context isNil ifTrue:[
+			self triggerEvent: #stepOver.
+			^self.
+		].
+	
+		"If the instruction we just executed was the last instruction of 
+	 	an initializer (`let` or `register`), then context's PC whould
+	 	be set one beyond the last instruction in initializer (see 
+	 	JibInterpter >> interpret1 for explanation) and  interpreter's
+	 	context would be already be set to next initializer or entry 
+	 	function. Again, in that case we're done."
+	
+		(context pc) == (context function instrs size + 1) ifTrue:[
+			self assert: context function isFn not.
+			self assert: context caller isNil.
+		
+			self triggerEvent: #stepOver.
+			^self.		
+		].
 	].
 	
-	"
-	 Now, if the current (top-most) context is not the context 
+	"Now, if the current (top-most) context is not the context 
 	 in which we should step-over (either never was, or the instruction
 	 stepped above was a call), then we arrange a temporary breakpoint
 	 right after the call instruction and continue until this (or some other)
 	 breakpoint hits.
 	
-	 Also: the `self step` above may have executed entry point's `end` 
-	 instruction in which case interpreter terminates (there's no more 
-	 instructions to execute). Hence the below notNil guard."	
-	interpreter context notNil ifTrue:[
-		context ~~ interpreter context ifTrue:[
-			| instr break |
-				
-			instr := context function instrs at: context pc. 
-			break := JibInterpreterBreakpoint at: instr.
-			break temporary: true.
+	 It may happen that context is for initializer and that current 
+	 instruction in that context is a call *and also* a last instruction
+	 of the initializer. In that case, the 'next' instruction is
+	 is the first instruction of next entry in interpreter's todo
+	 (since initializers do not have `end`, see JibInterpreter >> interpret1).
+	"
 	
-			interpreter addBreakpoint: break.
-		
-			self cont.
+	context ~~ interpreter context ifTrue:[
+		| instr break |
+				
+		(context function isFn not and:[(context pc) == (context function instrs size + 1)]) ifTrue:[
+			instr := interpreter todo first function instrs at: 1.
+		] ifFalse:[
+			instr := context function instrs at: context pc.
 		].
+				
+		break := JibInterpreterBreakpoint at: instr.
+		break temporary: true.
+	
+		interpreter addBreakpoint: break.
+		
+		self cont.
 	].
+	
 	self triggerEvent: #stepOver 
 	
 ]

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -325,10 +325,7 @@ JibInterpreter >> setRegister: id to: value [
 ]
 
 { #category : #'debugging support' }
-JibInterpreter >> stepInto: steppingContext [
-	context == steppingContext ifTrue:[
-		self interpret1.
-	] ifFalse:[
-		self notYetImplemented
-	]
+JibInterpreter >> todo [
+	"Return the 'TODO' list. Private, use with care!"
+	^ todo
 ]


### PR DESCRIPTION
This commit fixes some edge cases in step-into and step-over operations when stepping the initializer context's last instruction. The complication here comes from the fact that initializers (unlike functions) have no terminating `end` instruction.