### PR TITLE
Add 'finish' debug operation

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
@@ -314,3 +314,135 @@ fn zmain() {
 	self assert: interpreter context function isFn.
 	self assert: interpreter context function id = 'zmain'.
 ]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_05a [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+val zf : (%bv32) ->  %bv32
+
+fn zf(zarg) {
+  zz39 : %bv32 `1;
+  zz39 = 0b00000000000000000000000000101010 `2;
+  return = zz39 `3;
+  end;
+}
+
+val zmain : (%bv32) ->  %bv32
+
+fn zmain(zarg) {
+  zz1 : %bv32 `1;
+  zz1 = zf(zarg) `2;
+  return = zz1 `3;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { 0 toBitVector: 32 }.
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function id = 'zmain'.
+	session stepInto: interpreter context. "zz1 : %bv32 `1;"
+	session stepInto: interpreter context. "zz1 = zf(zarg) `2;"
+
+	self assert: interpreter context function id = 'zf'.
+	self assert: interpreter context pc = 1.
+
+	session finish: interpreter context.
+
+	self assert: interpreter context function id = 'zmain'.
+	self assert: interpreter context pc = 3.
+]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_05b [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+val zf : (%bv32) ->  %bv32
+
+fn zf(zarg) {
+  zz39 : %bv32 `1;
+  zz39 = 0b00000000000000000000000000101010 `2;
+  return = zz39 `3;
+  end;
+}
+
+val zmain : (%bv32) ->  %bv32
+
+fn zmain(zarg) {
+  zz1 : %bv32 `1;
+  zz1 = zf(zarg) `2;
+  return = zz1 `3;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: { 0 toBitVector: 32 }.
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function id = 'zmain'.
+	session stepInto: interpreter context. "zz1 : %bv32 `1;"
+	session stepInto: interpreter context. "zz1 = zf(zarg) `2;"
+
+	self assert: interpreter context function id = 'zf'.
+	self assert: interpreter context pc = 1.
+
+	session finish: interpreter context caller. "finish zmain"
+
+	self assert: interpreter context isNil.
+]
+
+{ #category : #tests }
+JibDebuggerSessionTests >> test_05c [
+	| program main interpreter session |
+
+	program := JibParser parse:'
+let (zxlen_val: %i64) {
+  zz40 : %i64;
+  zz40 = 64;
+  zxlen_val = zz40;
+}
+
+val zmain : () -> %i64
+
+fn zmain() {
+  return = zxlen_val;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: {  }.
+	session := JibDebuggerSession for: interpreter.
+
+	"
+	JibDebugger openOn: session.
+	"
+	self assert: interpreter context function isLet.
+
+	session finish: interpreter context. "finish let zxlen_val"
+
+	self assert: interpreter context function id = 'zmain'.
+
+	session finish: interpreter context. "finish zmain"
+
+	self assert: interpreter context isNil.
+
+
+]

--- a/src/Sail-Jib-Interpreter/JibDebuggerDebugActionFinish.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebuggerDebugActionFinish.class.st
@@ -1,0 +1,52 @@
+Class {
+	#name : #JibDebuggerDebugActionFinish,
+	#superclass : #DebugAction,
+	#category : #'Sail-Jib-Interpreter-Debugger'
+}
+
+{ #category : #acccessing }
+JibDebuggerDebugActionFinish class >> actionFor: aDebugger [
+	<gtStackDebuggingAction>
+
+	^ self forDebugger: aDebugger
+]
+
+{ #category : #acccessing }
+JibDebuggerDebugActionFinish class >> actionType [
+	<debuggingAction>
+	<contextMenuDebuggingAction>
+]
+
+{ #category : #testing }
+JibDebuggerDebugActionFinish >> appliesToDebugger: aDebugger [
+
+	^ aDebugger isKindOf: JibDebugger
+]
+
+{ #category : #accessing }
+JibDebuggerDebugActionFinish >> defaultIcon [
+
+	^ GLMUIThemeExtraIcons glamorousOver
+]
+
+{ #category : #accessing }
+JibDebuggerDebugActionFinish >> defaultLabel [
+	^ 'Finish'
+]
+
+{ #category : #accessing }
+JibDebuggerDebugActionFinish >> defaultOrder [
+
+	^ 25
+]
+
+{ #category : #actions }
+JibDebuggerDebugActionFinish >> executeAction [
+	self session finish: self selectedContext
+
+]
+
+{ #category : #accessing }
+JibDebuggerDebugActionFinish >> help [
+	^ 'Execute until selected context returns'.
+]

--- a/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
+++ b/src/Sail-Jib-Interpreter/JibDebuggerSession.class.st
@@ -14,6 +14,7 @@ JibDebuggerSession class >> debuggingActionsForPragma: aSymbol for: aDebugger [
 		"RestartDebugAction ."
 		StepIntoDebugAction .
 		StepOverDebugAction .
+		JibDebuggerDebugActionFinish .
 	} inject: OrderedCollection new
 		into: [ :currentActions :aClass |
 			currentActions
@@ -78,6 +79,32 @@ JibDebuggerSession >> cont [
 	] on: JibInterpreterBreakpointHitNotification do: [ :hit |
 		"Stop"
 	].
+]
+
+{ #category : #'debugging actions' }
+JibDebuggerSession >> finish: context [
+	| caller |
+
+	caller := context caller.
+	caller isNil ifTrue:[
+		interpreter todo notEmpty ifTrue:[
+			caller := interpreter todo first.
+		]
+	].
+
+	caller notNil ifTrue:[
+		| instr break |
+
+		instr := caller function instrs at: caller pc.
+		break := JibInterpreterBreakpoint at: instr.
+		break temporary: true.
+
+		interpreter addBreakpoint: break.
+	].
+
+	self cont.
+	self triggerEvent: #finish
+
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Like in GDB, the 'finish' operation executes until selected context returns (or a breakpoint is hit).