### PR TITLE
Fix liveness after realizing that `Instr_Decl` is not mere declaration

### DIFF
--- a/src/Sail-Jib/Instr_Decl.class.st
+++ b/src/Sail-Jib/Instr_Decl.class.st
@@ -28,6 +28,13 @@ Instr_Decl >> childrenDo: aBlock [
 	
 ]
 
+{ #category : #enumerating }
+Instr_Decl >> defdIdsDo: aBlock [
+	"Evaluate `aBlock` for each id defined (assigned) by this instruction"
+
+	aBlock value: id
+]
+
 { #category : #accessing }
 Instr_Decl >> id [
 	^ id


### PR DESCRIPTION
In today's debugging session we came to realization that `Instr_Decl` is not mere declaration of a type of a variable, but also "assigns" initial "undefined" value.

For example:

    def fn (za) {
      zz1 : %i;
      return = zz1;
      end;
    }

is valid and returns unconstrained int. Therefore, we need to treat `Instr_Decl` as "defining" given variable for the purpose of liveness computation. This commit does so.

Note, that this means that Jib is not SSA - common pattern

   zz2 : %bv32;
   zz2 = #xABCD1234;

means that `zz2` is "redefined".