### PR TITLE
Introduce new base class for Jib definition that contain code

### DIFF
--- a/src/Sail-Jib-Interpreter/Def_Fn.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Fn.extension.st
@@ -4,8 +4,3 @@ Extension { #name : #'Def_Fn' }
 Def_Fn >> hasCode [
 	^ true
 ]
-
-{ #category : #'*Sail-Jib-Interpreter' }
-Def_Fn >> instrAt: pc [
-	^instrs at: pc
-]

--- a/src/Sail-Jib-Interpreter/Def_Let.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Let.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #'Def_Let' }
 
 { #category : #'*Sail-Jib-Interpreter' }
-Def_Let >> hasCode [
-	^ self hasInitializer
-]
-
-{ #category : #'*Sail-Jib-Interpreter' }
 Def_Let >> hasInitializer [
-	^ instrs notEmpty
+	^ self hasCode
 ]

--- a/src/Sail-Jib-Interpreter/Def_Register.extension.st
+++ b/src/Sail-Jib-Interpreter/Def_Register.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #'Def_Register' }
 
 { #category : #'*Sail-Jib-Interpreter' }
-Def_Register >> hasCode [
-	^ self hasInitializer
-]
-
-{ #category : #'*Sail-Jib-Interpreter' }
 Def_Register >> hasInitializer [
-	^ instrs notEmpty
+	^ self hasCode
 ]

--- a/src/Sail-Jib-Interpreter/JibDefWithCode.extension.st
+++ b/src/Sail-Jib-Interpreter/JibDefWithCode.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #JibDefWithCode }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+JibDefWithCode >> hasCode [
+	^ instrs notNil and:[instrs notEmpty]
+]

--- a/src/Sail-Jib/Def_Fn.class.st
+++ b/src/Sail-Jib/Def_Fn.class.st
@@ -1,11 +1,9 @@
 Class {
 	#name : #'Def_Fn',
-	#superclass : #JibDef,
+	#superclass : #JibDefWithCode,
 	#instVars : [
 		'id',
-		'ids',
-		'instrs',
-		'blocks'
+		'ids'
 	],
 	#category : #'Sail-Jib'
 }
@@ -24,76 +22,15 @@ Def_Fn >> argNames [
 	^ ids
 ]
 
-{ #category : #accessing }
-Def_Fn >> blocks [
-	blocks isNil ifTrue:[
-		blocks := JibFnBodyBlock analyze: self.
-	].
-	^ blocks
-]
-
 { #category : #enumerating }
 Def_Fn >> childrenDo: aBlock [
 	instrs do: aBlock
 	
 ]
 
-{ #category : #inspecting }
-Def_Fn >> gtCFGIn: composite [
-	<gtInspectorPresentationOrder: 50>
-	composite roassal3 title: 'CFG'; initializeCanvas: [
-		| canvas blocksG edges |
-
-		canvas := RSCanvas new.
-		blocksG := RSGroup new.
-		self blocks do:[:block |
-			| box label node |
-
-			label := RSLabel new text: block displayString.
-			box := RSShapeFactory box
-							border: (RSBorder new width: 2; color: Color black);
-							cornerRadius: 5;
-							color: (Color gray: 0.9);
-							width: label encompassingRectangle width + 16;
-							height: label encompassingRectangle height + 16.
-			RSLocation new center; outer; stick: label on: box.
-			node := (RSComposite new model: block; shapes: { box . label }) @ RSDraggable.
-
-			blocksG add: node.
-			canvas add: node
-		].
-
-		edges := RSEdgeBuilder arrowedLine
-							attachPoint: RSBorderAttachPoint new;
-							yourself.
-
-		edges
-			canvas: canvas; "moveBehind;" width: 2;
-			shapes: blocksG; connectToAll: #successors.
-
-		RSVerticalLineLayout on: blocksG.
-		canvas @ RSCanvasController
-	]
-]
-
-{ #category : #inspecting }
-Def_Fn >> gtInstrsIn: composite [
-	<gtInspectorPresentationOrder: 20>
-
-	^ composite fastList
-		title: 'Instructions';
-		display: [ instrs ];
-		format: [ :insn | insn ]
-]
-
 { #category : #accessing }
 Def_Fn >> id [
 	^ id
-]
-
-{ #category : #accessing }
-Def_Fn >> instrs [
-	^ instrs
 ]
 
 { #category : #testing }

--- a/src/Sail-Jib/Def_Let.class.st
+++ b/src/Sail-Jib/Def_Let.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #'Def_Let',
-	#superclass : #JibDef,
+	#superclass : #JibDefWithCode,
 	#instVars : [
-		'ids',
-		'instrs'
+		'ids'
 	],
 	#category : #'Sail-Jib'
 }
@@ -35,11 +34,6 @@ Def_Let >> displayStringOn: aStream [
 	aStream nextPutAll: 'let '.
 	ids do:[:nameAndType | aStream nextPutAll: nameAndType key zdecode ]
 		  separatedBy:[aStream nextPutAll: ', ']
-]
-
-{ #category : #accessing }
-Def_Let >> instrs [
-	^instrs
 ]
 
 { #category : #testing }

--- a/src/Sail-Jib/Def_Register.class.st
+++ b/src/Sail-Jib/Def_Register.class.st
@@ -1,10 +1,9 @@
 Class {
 	#name : #'Def_Register',
-	#superclass : #JibDef,
+	#superclass : #JibDefWithCode,
 	#instVars : [
 		'id',
-		'ty',
-		'instrs'
+		'ty'
 	],
 	#category : #'Sail-Jib'
 }
@@ -38,11 +37,6 @@ Def_Register >> displayStringOn: aStream [
 { #category : #accessing }
 Def_Register >> id [
 	^ id
-]
-
-{ #category : #accessing }
-Def_Register >> instrs [
-	^ instrs
 ]
 
 { #category : #testing }

--- a/src/Sail-Jib/JibDefWithCode.class.st
+++ b/src/Sail-Jib/JibDefWithCode.class.st
@@ -1,0 +1,76 @@
+Class {
+	#name : #JibDefWithCode,
+	#superclass : #JibDef,
+	#instVars : [
+		'instrs',
+		'blocks'
+	],
+	#category : #'Sail-Jib'
+}
+
+{ #category : #accessing }
+JibDefWithCode >> blocks [
+	blocks isNil ifTrue:[
+		blocks := JibFnBodyBlock analyze: self.
+	].
+	^ blocks
+]
+
+{ #category : #inspecting }
+JibDefWithCode >> gtCFGIn: composite [
+	<gtInspectorPresentationOrder: 50>
+	composite roassal3 title: 'CFG'; initializeCanvas: [
+		| canvas blocksG edges |
+
+		canvas := RSCanvas new.
+		blocksG := RSGroup new.
+		self blocks do:[:block |
+			| box label node |
+
+			label := RSLabel new text: block displayString.
+			box := RSShapeFactory box
+							border: (RSBorder new width: 2; color: Color black);
+							cornerRadius: 5;
+							color: (Color gray: 0.9);
+							width: label encompassingRectangle width + 16;
+							height: label encompassingRectangle height + 16.
+			RSLocation new center; outer; stick: label on: box.
+			node := (RSComposite new model: block; shapes: { box . label }) @ RSDraggable.
+
+			blocksG add: node.
+			canvas add: node
+		].
+
+		edges := RSEdgeBuilder arrowedLine
+							attachPoint: RSBorderAttachPoint new;
+							yourself.
+
+		edges
+			canvas: canvas; "moveBehind;" width: 2;
+			shapes: blocksG; connectToAll: #successors.
+
+		RSVerticalLineLayout on: blocksG.
+		canvas @ RSCanvasController
+	]
+]
+
+{ #category : #inspecting }
+JibDefWithCode >> gtInstructionsIn: composite [
+	<gtInspectorPresentationOrder: 20>
+
+	^ composite fastTable
+		title: 'Instructions';
+		display: [ instrs ];
+		column: 'Index'
+			evaluated: [ :insn | (instrs indexOf: insn) - 1];
+		column: 'Instruction'
+			evaluated: [ :insn | insn unparsedString ];
+		selectionAct: [ :list | list selection inspect ]
+			iconName: #smallInspectIt
+			entitled: 'Inspect'.
+]
+
+{ #category : #accessing }
+JibDefWithCode >> instrs [
+	^ instrs
+]


### PR DESCRIPTION
This commit introduces new abstract base class - `JibDefWithCode` - for all definitions that may contain code (a sequence of Jib instructions) to reduce code duplication.