### PR TITLE
Add basic support for unit type

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -285,3 +285,83 @@ fn zmain(zarg) {
 
 
 ]
+
+{ #category : #tests }
+JibInterpreterTests >> test_09a [
+	| program main interpreter |
+	program := JibParser parse:'
+
+val zmain : () -> %unit
+fn  zmain() {	
+  return = ();
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: {  }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal isDatatype.
+	self assert: interpreter retVal sort name asString = '%unit'.
+	self assert: interpreter retVal printString = '|()|'.
+	
+
+]
+
+{ #category : #tests }
+JibInterpreterTests >> test_09b [
+	| program main interpreter |
+	program := JibParser parse:'
+
+val zmain : () -> %unit
+fn  zmain() {	
+	zz1 : %unit;
+	zz1 = ();
+  return = zz1;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: {  }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal isDatatype.
+	self assert: interpreter retVal sort name asString = '%unit'.
+	self assert: interpreter retVal printString = '|()|'.
+	
+
+]
+
+{ #category : #tests }
+JibInterpreterTests >> test_09c [
+	| program main interpreter |
+	program := JibParser parse:'
+
+val zmain : () -> %unit
+fn  zmain() {	
+	zz1 : %unit;
+  return = zz1;
+  end;
+}
+
+'.
+
+	main := program lookupFunction: 'zmain'.
+
+	interpreter := JibInterpreter for: main arguments: {  }.
+
+	interpreter interpret.
+
+	self assert: interpreter retVal isDatatype.
+	self assert: interpreter retVal sort name asString = '%unit'.
+	
+
+]

--- a/src/Sail-Jib-Interpreter/Exp_Unit.extension.st
+++ b/src/Sail-Jib-Interpreter/Exp_Unit.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #'Exp_Unit' }
+
+{ #category : #'*Sail-Jib-Interpreter' }
+Exp_Unit >> interpretIn: interpreter [
+	^ interpreter interpretUnit: self
+]

--- a/src/Sail-Jib-Interpreter/JibInterpreter.class.st
+++ b/src/Sail-Jib-Interpreter/JibInterpreter.class.st
@@ -285,6 +285,17 @@ JibInterpreter >> interpretMonomorphize: insn [
 
 ]
 
+{ #category : #'interpreting - insns' }
+JibInterpreter >> interpretUnit: insn [
+	| sort unit |
+	
+	sort := insn environment lookupSortForUnit.
+	unit := (sort constructor: 0) value.
+	^unit
+
+
+]
+
 { #category : #interpreting }
 JibInterpreter >> interpretWhileFalse: condition [
 	"Interpret instruction by instruction as long as `condition` evaluates to `false`"

--- a/src/Sail-Jib/JibEnvironment.class.st
+++ b/src/Sail-Jib/JibEnvironment.class.st
@@ -24,6 +24,11 @@ JibEnvironment >> initializeWithNode: aJibProgramNode [
 	node := aJibProgramNode.
 ]
 
+{ #category : #lookup }
+JibEnvironment >> lookupSortForUnit [
+	^self parent lookupSortForUnit
+]
+
 { #category : #accessing }
 JibEnvironment >> node [
 	"Return the Jib program node this environment is associated with."

--- a/src/Sail-Jib/JibProgramEnvironment.class.st
+++ b/src/Sail-Jib/JibProgramEnvironment.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #JibProgramEnvironment,
 	#superclass : #JibEnvironment,
 	#instVars : [
-		'context'
+		'context',
+		'unitSort'
 	],
 	#category : #'Sail-Jib-Environment'
 }
@@ -16,6 +17,15 @@ JibProgramEnvironment >> context [
 JibProgramEnvironment >> initializeWithNode: aJibProgramNode [
 	node := aJibProgramNode.
 	context := Z3Context fromDefault.
+	unitSort := context mkEnumerationSort: '%unit' 
+	                             elements: { '()' }
+	                               consts: Cell new
+	                              testers: Cell new.	
+]
+
+{ #category : #lookup }
+JibProgramEnvironment >> lookupSortForUnit [
+	^ unitSort 
 ]
 
 { #category : #accessing }

--- a/src/Sail-Jib/Ty_Unit.class.st
+++ b/src/Sail-Jib/Ty_Unit.class.st
@@ -10,6 +10,11 @@ Ty_Unit class >> inducedParser [
 	==> [ :_ | self new ]
 ]
 
+{ #category : #accessing }
+Ty_Unit >> sort [
+	^ self environment lookupSortForUnit.
+]
+
 { #category : #printing }
 Ty_Unit >> unparseOn: aStream [
 	aStream nextPutAll:'%unit'


### PR DESCRIPTION
This commit add basic support for Jib's `%unit` type. Unit is modeled as Z3 enum named `%unit` with only one value named `()`.