### PR TITLE
Disallow zero argument functions

### DIFF
--- a/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibDebuggerSessionTests.class.st
@@ -103,9 +103,9 @@ register zPC : %bv64 {
 	zPC = 0xCAFE0000CAFE0000;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain() {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -114,7 +114,7 @@ fn zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: #().
+	interpreter := JibInterpreter for: main arguments: #(1).
 	session := JibDebuggerSession for: interpreter.
 
 	"
@@ -135,19 +135,19 @@ JibDebuggerSessionTests >> test_03c [
 	program := JibParser parse:'
 
 let (zxlen_val: %i64) {
-  zxlen_val = zf();
+  zxlen_val = zf(());
 }
 
-val zf : () -> %i64
+val zf : (%unit) -> %i64
 
-fn zf() {
+fn zf(_) {
   return = 64;
   end;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain() {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -156,7 +156,7 @@ fn zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: #().
+	interpreter := JibInterpreter for: main arguments: #(1).
 	session := JibDebuggerSession for: interpreter.
 
 	"
@@ -275,19 +275,19 @@ JibDebuggerSessionTests >> test_04c [
 	program := JibParser parse:'
 
 let (zxlen_val: %i64) {
-  zxlen_val = zf();
+  zxlen_val = zf(());
 }
 
-val zf : () -> %i64
+val zf : (%unit) -> %i64
 
-fn zf() {
+fn zf(_) {
   return = 64;
   end;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain() {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -296,7 +296,7 @@ fn zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: #().
+	interpreter := JibInterpreter for: main arguments: #(1).
 	session := JibDebuggerSession for: interpreter.
 
 	"
@@ -417,9 +417,9 @@ let (zxlen_val: %i64) {
   zxlen_val = zz40;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain() {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -428,7 +428,7 @@ fn zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 	session := JibDebuggerSession for: interpreter.
 
 	"

--- a/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
+++ b/src/Sail-Jib-Interpreter-Tests/JibInterpreterTests.class.st
@@ -102,9 +102,9 @@ JibInterpreterTests >> test_03 [
 	program := JibParser parse:'
 register zPC : %bv32
 
-val zmain : () ->  %bv32
+val zmain : (%i) ->  %bv32
 
-fn zmain() {
+fn zmain(_) {
   zz39 : %bv32;
   zz39 = 0x0000002A;
   zPC = zz39;
@@ -113,13 +113,11 @@ fn zmain() {
   return = zz40;
   end;
 }
-
-
 '.
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: { }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -196,9 +194,9 @@ let (zxlen_val: %i64) {
   zxlen_val = zz40;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain(zarg) {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -207,7 +205,7 @@ fn zmain(zarg) {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -228,9 +226,9 @@ register zxlen_val : %i64 {
   zxlen_val = zz40;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain(zarg) {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -255,19 +253,19 @@ JibInterpreterTests >> test_07 [
 	program := JibParser parse:'
 
 let (zxlen_val: %i64) {
-  zxlen_val = zf();
+  zxlen_val = zf(());
 }
 
-val zf : () -> %i64
+val zf : (%unit) -> %i64
 
-fn zf() { 
+fn zf(_) {
   return = 64;
   end;
 }
 
-val zmain : () -> %i64
+val zmain : (%i) -> %i64
 
-fn zmain(zarg) {
+fn zmain(_) {
   return = zxlen_val;
   end;
 }
@@ -276,7 +274,7 @@ fn zmain(zarg) {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: { -1 toBitVector: 16 }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -300,8 +298,8 @@ enum ziop {
   zRISCV_ANDI
 }
 
-val zmain : () -> %enum ziop
-fn  zmain() {
+val zmain : (%i) -> %enum ziop
+fn  zmain(_) {
   return = zRISCV_ADDI;
   end;
 }
@@ -310,7 +308,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -334,8 +332,8 @@ enum ziop {
   zRISCV_ANDI
 }
 
-val zmain : () -> %enum ziop
-fn  zmain() {
+val zmain : (%i) -> %enum ziop
+fn  zmain(_) {
 	zz1 : %enum ziop;
 	zz1 = zRISCV_ANDI;
   return = zz1;
@@ -346,7 +344,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -370,8 +368,8 @@ enum ziop {
   zRISCV_ANDI
 }
 
-val zmain : () -> %enum ziop
-fn  zmain() {
+val zmain : (%i) -> %enum ziop
+fn  zmain(_) {
 	zz1 : %enum ziop;
   return = zz1;
   end;
@@ -381,7 +379,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -396,8 +394,8 @@ JibInterpreterTests >> test_09a [
 	| program main interpreter |
 	program := JibParser parse:'
 
-val zmain : () -> %unit
-fn  zmain() {	
+val zmain : (%i) -> %unit
+fn  zmain(_) {
   return = ();
   end;
 }
@@ -406,7 +404,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -422,8 +420,8 @@ JibInterpreterTests >> test_09b [
 	| program main interpreter |
 	program := JibParser parse:'
 
-val zmain : () -> %unit
-fn  zmain() {	
+val zmain : (%i) -> %unit
+fn  zmain(_) {
 	zz1 : %unit;
 	zz1 = ();
   return = zz1;
@@ -434,7 +432,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 
@@ -450,8 +448,8 @@ JibInterpreterTests >> test_09c [
 	| program main interpreter |
 	program := JibParser parse:'
 
-val zmain : () -> %unit
-fn  zmain() {	
+val zmain : (%i) -> %unit
+fn  zmain(_) {
 	zz1 : %unit;
   return = zz1;
   end;
@@ -461,7 +459,7 @@ fn  zmain() {
 
 	main := program lookupFunction: 'zmain'.
 
-	interpreter := JibInterpreter for: main arguments: {  }.
+	interpreter := JibInterpreter for: main arguments: { 1 }.
 
 	interpreter interpret.
 

--- a/src/Sail-Jib-Parsing/JibParser.class.st
+++ b/src/Sail-Jib-Parsing/JibParser.class.st
@@ -27,7 +27,7 @@ Class {
 
 { #category : #accessing }
 JibParser class >> id [
-	^(#letter asParser, (#word asParser / $_ asParser) star) flatten
+	^((#letter asParser / $_ asParser), (#word asParser / $_ asParser) star) flatten
 ]
 
 { #category : #'rules - exp' }

--- a/src/Sail-Jib-Tests/JibParsingTest.class.st
+++ b/src/Sail-Jib-Tests/JibParsingTest.class.st
@@ -262,6 +262,24 @@ JibParsingTest >> test_field_of_unwrap_of_field_of_struct [
 	"
 ]
 
+{ #category : #'tests - individual defs' }
+JibParsingTest >> test_fn_empty_args [
+	| val |
+
+	val := defParser parse: 'fn zf () {
+	return = 1;
+	end;
+}'.
+	self assert: val isPetitFailure.
+
+	val := defParser parse: 'fn zf ( ) {
+	return = 1;
+	end;
+}'.
+
+	self assert: val isPetitFailure.
+]
+
 { #category : #'tests - expressions' }
 JibParsingTest >> test_id [
 	| src val |
@@ -451,4 +469,15 @@ JibParsingTest >> test_val [
 	| val |
 	val := defParser parse: 'val zundefined_bitvector = "undefined_bitvector" : (%i) ->  %bv'.
 	self assert: (val isKindOf: Def_Val)
+]
+
+{ #category : #'tests - individual defs' }
+JibParsingTest >> test_val_empty_args [
+	| val |
+
+	val := defParser parse: 'val zf : () -> %bv'.
+	self assert: val isPetitFailure.
+
+	val := defParser parse: 'val zf : ( ) -> %bv'.
+	self assert: val isPetitFailure.
 ]

--- a/src/Sail-Jib/Def_Extern.class.st
+++ b/src/Sail-Jib/Def_Extern.class.st
@@ -15,7 +15,7 @@ Def_Extern class >> inducedParser [
 	    '=' asParser trim,
 	    PPParser doubleQuoted trim,
 	    $: asParser trim
-	    , Ty asParser trim commaSeparated parens trim
+	    , (Ty asParser trim commaSeparated parens trim ==> [ :tys | tys ifNotNil:[tys] ifNil: [ PPFailure message:'Argument type list cannot be empty!' ] ])
 	    , '->' asParser trim
 	    , Ty asParser trim
 	    construct: #(- id - ext - tys - ty)

--- a/src/Sail-Jib/Def_Fn.class.st
+++ b/src/Sail-Jib/Def_Fn.class.st
@@ -12,7 +12,7 @@ Class {
 Def_Fn class >> inducedParser [
 	^ 'fn' asParser trim
 	, JibParser id trim
-	, (JibParser id trim commaList ==> [ :x|x ifNil:#() ])
+	, (JibParser id trim commaList ==> [ :ids | ids ifNotNil:[ids] ifNil: [ PPFailure message:'Argument name list cannot be empty!' ] ])
 	, (JibInstr asParser, $; asParser trim ==> #first) star braces
 	construct: #(- id ids instrs)
 ]

--- a/src/Sail-Jib/Def_Val.class.st
+++ b/src/Sail-Jib/Def_Val.class.st
@@ -14,7 +14,7 @@ Def_Val class >> inducedParser [
 	^'val' asParser trim
 	, JibParser id trim
 	, $: asParser trim
-	, (Ty asParser trim commaSeparated parens ==> [ :x | x ifNil:#() ])
+	, (Ty asParser trim commaSeparated parens ==> [ :tys | tys ifNotNil:[tys] ifNil: [ PPFailure message:'Argument type list cannot be empty!' ] ])
 	, '->' asParser trim
 	, Ty asParser trim
 	construct: #(- id - tys - ty)


### PR DESCRIPTION
It turned out that Jib does not allow functions with no arguments.
Upstream rejects following program (tested by `isla-execute-function`):

```
register zPC : %bv32

val zmain : () -> %bv32

fn zmain() {
  return = #xCAFEAFFE;
  end;
}
```

Instead, one should use one argument of type `%unit` like (again,
tested by `isla-execute-function`):

```
register zPC : %bv32

val zmain : (%unit) -> %bv32

fn zmain(_) {
  return = #xCAFEAFFE;
  end;
}
```

This actually make things easier when creating Sprite.