### PR TITLE
Initial stab at RISCV "quattropod" Sail Model

### DIFF
--- a/examples/Sail/GNUmakefile
+++ b/examples/Sail/GNUmakefile
@@ -1,0 +1,7 @@
+all: ../Jib/riscv_quattropod.ir
+
+../Jib/riscv_quattropod.ir: riscv_quattropod.sail
+	sail --all-warnings --list-files --isla $<  -o ../Jib/riscv_quattropod
+
+clean:
+	rm ../Jib/riscv_quattropod.ir

--- a/examples/Sail/riscv_quattropod.sail
+++ b/examples/Sail/riscv_quattropod.sail
@@ -1,0 +1,350 @@
+/*=======================================================================================*/
+/*  RISCV Sail Model                                                                     */
+/*                                                                                       */
+/*  This Sail RISC-V architecture model, comprising all files and                        */
+/*  directories except for the snapshots of the Lem and Sail libraries                   */
+/*  in the prover_snapshots directory (which include copies of their                     */
+/*  licences), is subject to the BSD two-clause licence below.                           */
+/*                                                                                       */
+/*  Copyright (c) 2017-2025                                                              */
+/*    Prashanth Mundkur                                                                  */
+/*    Rishiyur S. Nikhil and Bluespec, Inc.                                              */
+/*    Jon French                                                                         */
+/*    Brian Campbell                                                                     */
+/*    Robert Norton-Wright                                                               */
+/*    Alasdair Armstrong                                                                 */
+/*    Thomas Bauereiss                                                                   */
+/*    Shaked Flur                                                                        */
+/*    Christopher Pulte                                                                  */
+/*    Peter Sewell                                                                       */
+/*    Alexander Richardson                                                               */
+/*    Hesham Almatary                                                                    */
+/*    Jessica Clarke                                                                     */
+/*    Microsoft, for contributions by Robert Norton-Wright and Nathaniel Wesley Filardo  */
+/*    Peter Rugg                                                                         */
+/*    Aril Computer Corp., for contributions by Scott Johnson                            */
+/*    Philipp Tomsich                                                                    */
+/*    VRULL GmbH, for contributions by its employees                                     */
+/*    LabWare                                                                            */
+/*                                                                                       */
+/*  All rights reserved.                                                                 */
+/*                                                                                       */
+/*  This software was developed by the above within the Rigorous                         */
+/*  Engineering of Mainstream Systems (REMS) project, partly funded by                   */
+/*  EPSRC grant EP/K008528/1, at the Universities of Cambridge and                       */
+/*  Edinburgh.                                                                           */
+/*                                                                                       */
+/*  This software was developed by SRI International and the University of               */
+/*  Cambridge Computer Laboratory (Department of Computer Science and                    */
+/*  Technology) under DARPA/AFRL contract FA8650-18-C-7809 ("CIFV"), and                 */
+/*  under DARPA contract HR0011-18-C-0016 ("ECATS") as part of the DARPA                 */
+/*  SSITH research programme.                                                            */
+/*                                                                                       */
+/*  This project has received funding from the European Research Council                 */
+/*  (ERC) under the European Union’s Horizon 2020 research and innovation                */
+/*  programme (grant agreement 789108, ELVER).                                           */
+/*                                                                                       */
+/*                                                                                       */
+/*  Redistribution and use in source and binary forms, with or without                   */
+/*  modification, are permitted provided that the following conditions                   */
+/*  are met:                                                                             */
+/*  1. Redistributions of source code must retain the above copyright                    */
+/*     notice, this list of conditions and the following disclaimer.                     */
+/*  2. Redistributions in binary form must reproduce the above copyright                 */
+/*     notice, this list of conditions and the following disclaimer in                   */
+/*     the documentation and/or other materials provided with the                        */
+/*     distribution.                                                                     */
+/*                                                                                       */
+/*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''                   */
+/*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED                    */
+/*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                      */
+/*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR                  */
+/*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                         */
+/*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                     */
+/*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                     */
+/*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                  */
+/*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,                   */
+/*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT                   */
+/*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF                   */
+/*  SUCH DAMAGE.                                                                         */
+/*=======================================================================================*/
+
+$span start PREAMBLE
+
+default Order dec
+$include <prelude.sail>
+
+$span end
+
+val sign_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+val zero_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+
+function sign_extend(m, v) = sail_sign_extend(v, m)
+function zero_extend(m, v) = sail_zero_extend(v, m)
+
+val bool_to_bits : bool -> bits(1)
+function bool_to_bits x = if x then 0b1 else 0b0
+
+infix 4 <_s
+infix 4 >=_s
+infix 4 <_u
+infix 4 >=_u
+infix 4 <=_u
+
+val operator <_s  : forall 'n, 'n > 0. (bits('n), bits('n)) -> bool
+val operator >=_s : forall 'n, 'n > 0. (bits('n), bits('n)) -> bool
+val operator <_u  : forall 'n. (bits('n), bits('n)) -> bool
+val operator >=_u : forall 'n. (bits('n), bits('n)) -> bool
+val operator <=_u : forall 'n. (bits('n), bits('n)) -> bool
+
+function operator <_s  (x, y) = signed(x) < signed(y)
+function operator >=_s (x, y) = signed(x) >= signed(y)
+function operator <_u  (x, y) = unsigned(x) < unsigned(y)
+function operator >=_u (x, y) = unsigned(x) >= unsigned(y)
+function operator <=_u (x, y) = unsigned(x) <= unsigned(y)
+
+val sub_vec = {c: "sub_bits", _: "sub_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
+
+overload operator - = {sub_vec}
+
+infix 7 >>
+infix 7 <<
+
+val "shift_bits_right" : forall 'n 'm. (bits('n), bits('m)) -> bits('n)
+val "shift_bits_left"  : forall 'n 'm. (bits('n), bits('m)) -> bits('n)
+
+overload operator >> = {shift_bits_right}
+overload operator << = {shift_bits_left}
+
+val xor_vec = {c: "xor_bits", _: "xor_vec"} : forall 'n. (bits('n), bits('n)) -> bits('n)
+
+overload operator ^ = {xor_vec}
+
+function shift_right_arith64 (v : bits(64), shift : bits(6)) -> bits(64) =
+    let v128 : bits(128) = sign_extend(v) in
+    (v128 >> shift)[63..0]
+
+function shift_right_arith32 (v : bits(32), shift : bits(5)) -> bits(32) =
+    let v64 : bits(64) = sign_extend(v) in
+    (v64 >> shift)[31..0]
+
+type xlen       : Int = 64
+type xlen_bytes : Int = 8
+type xlenbits         = bits(xlen)
+
+type regbits = bits(5)
+type regidx =  bits(5)
+
+val zeros : forall 'n, 'n >= 0. int('n) -> bits('n)
+function zeros n = replicate_bits(0b0, n)
+
+/* Architectural state */
+
+register PC : xlenbits
+register nextPC : xlenbits
+
+register Xs : vector(32, dec, xlenbits)
+
+/* Getters and setters for X registers (special case for zeros register, x0) */
+val rX : regbits -> xlenbits
+
+function rX(r) =
+  match r {
+    0b00000 => zero_extend(0x0),
+    _ => Xs[unsigned(r)]
+  }
+
+val wX : (regbits, xlenbits) -> unit
+
+function wX(r, v) =
+  if r != 0b00000 then {
+     Xs[unsigned(r)] = v;
+  }
+
+$span start XOVERLOAD
+overload X = {rX, wX}
+$span end
+
+/* Accessors for memory */
+val MEMr = impure { lem: "MEMr", coq: "MEMr", _ : "read_ram" } : forall 'n 'm, 'n >= 0.
+   (int('m), int('n), bits('m), bits('m)) -> bits(8 * 'n)
+
+val read_mem : forall 'n, 'n >= 0. (xlenbits, int('n)) -> bits(8 * 'n)
+function read_mem(addr, width) =
+    MEMr(sizeof(xlen), width, zero_extend(0x0), addr)
+
+enum retire_status = {
+  RETIRE_SUCCESS,  /* Instruction executed successfully */
+  RETIRE_FAIL      /* Instruction execution failed (invalid instruction, ...) */
+}
+
+enum iop = {
+  RISCV_ADDI,
+  RISCV_SLTI,
+  RISCV_SLTIU,
+  RISCV_XORI,
+  RISCV_ORI,
+  RISCV_ANDI
+}
+
+mapping encdec_iop : iop <-> bits(3) = {
+  RISCV_ADDI  <-> 0b000,
+  RISCV_SLTI  <-> 0b010,
+  RISCV_SLTIU <-> 0b011,
+  RISCV_ANDI  <-> 0b111,
+  RISCV_ORI   <-> 0b110,
+  RISCV_XORI  <-> 0b100
+}
+
+enum bop = {
+  RISCV_BEQ,
+  RISCV_BNE,
+  RISCV_BLT,
+  RISCV_BGE,
+  RISCV_BLTU,
+  RISCV_BGEU
+}
+
+mapping encdec_bop : bop <-> bits(3) = {
+  RISCV_BEQ  <-> 0b000,
+  RISCV_BNE  <-> 0b001,
+  RISCV_BLT  <-> 0b100,
+  RISCV_BGE  <-> 0b101,
+  RISCV_BLTU <-> 0b110,
+  RISCV_BGEU <-> 0b111
+}
+
+enum rop = {
+  RISCV_ADD,
+  RISCV_SUB,
+  RISCV_SLL,
+  RISCV_SLT,
+  RISCV_SLTU,
+  RISCV_XOR,
+  RISCV_SRL,
+  RISCV_SRA,
+  RISCV_OR,
+  RISCV_AND
+}
+
+/* Instruction decode and execute */
+scattered union ast
+
+val decode : bits(32) -> ast
+
+val execute : ast -> retire_status
+
+/* ****************************************************************** */
+
+union clause ast = ITYPE : (bits(12), regidx, regidx, iop)
+
+function clause decode imm : bits(12) @ rs1 : regbits @ op : bits(3) @ rd : regbits @ 0b0010011
+  = ITYPE(imm, rs1, rd, encdec_iop(op))
+
+function clause execute (ITYPE (imm, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let immext : xlenbits = sign_extend(imm);
+  let result : xlenbits = match op {
+    RISCV_ADDI  => rs1_val + immext,
+    RISCV_SLTI  => zero_extend(bool_to_bits(rs1_val <_s immext)),
+    RISCV_SLTIU => zero_extend(bool_to_bits(rs1_val <_u immext)),
+    RISCV_ANDI  => rs1_val & immext,
+    RISCV_ORI   => rs1_val | immext,
+    RISCV_XORI  => rs1_val ^ immext
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+union clause ast = BTYPE : (bits(13), regidx, regidx, bop)
+
+function clause decode imm7_6 : bits(1) @ imm7_5_0 : bits(6) @ rs2 : regidx @ rs1 : regidx @ op : bits(3) @ imm5_4_1 : bits(4) @ imm5_0 : bits(1) @ 0b1100011
+  = BTYPE(imm7_6 @ imm5_0 @ imm7_5_0 @ imm5_4_1 @ 0b0, rs2, rs1, encdec_bop(op))
+
+function clause execute (BTYPE(imm, rs2, rs1, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let taken : bool = match op {
+    RISCV_BEQ  => rs1_val == rs2_val,
+    RISCV_BNE  => rs1_val != rs2_val,
+    RISCV_BLT  => rs1_val <_s rs2_val,
+    RISCV_BGE  => rs1_val >=_s rs2_val,
+    RISCV_BLTU => rs1_val <_u rs2_val,
+    RISCV_BGEU => rs1_val >=_u rs2_val
+  };
+  let target : xlenbits = PC + sign_extend(imm);
+  /*
+   * For simplicity, we omit target address validation
+   * (memory unmapped or not executable and so on)
+   */
+  if taken then {
+    PC = target
+  };
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+
+union clause ast = RTYPE : (regidx, regidx, regidx, rop)
+
+function clause decode 0b0100000 @ rs2 : regidx @ rs1 : regidx@ 0b000 @ rd : regidx @ 0b0110011
+  = RTYPE(rs2, rs1, rd, RISCV_SUB)
+
+function clause execute (RTYPE(rs2, rs1, rd, op)) = {
+  let rs1_val = X(rs1);
+  let rs2_val = X(rs2);
+  let result : xlenbits = match op {
+    RISCV_ADD  => rs1_val + rs2_val,
+    RISCV_SLT  => zero_extend(bool_to_bits(rs1_val <_s rs2_val)),
+    RISCV_SLTU => zero_extend(bool_to_bits(rs1_val <_u rs2_val)),
+    RISCV_AND  => rs1_val & rs2_val,
+    RISCV_OR   => rs1_val | rs2_val,
+    RISCV_XOR  => rs1_val ^ rs2_val,
+    RISCV_SLL  => if   sizeof(xlen) == 32
+                  then rs1_val << (rs2_val[4..0])
+                  else rs1_val << (rs2_val[5..0]),
+    RISCV_SRL  => if   sizeof(xlen) == 32
+                  then rs1_val >> (rs2_val[4..0])
+                  else rs1_val >> (rs2_val[5..0]),
+    RISCV_SUB  => rs1_val - rs2_val,
+    RISCV_SRA  => if   sizeof(xlen) == 32
+                  then shift_right_arith32(rs1_val, rs2_val[4..0])
+                  else shift_right_arith64(rs1_val, rs2_val[5..0])
+  };
+  X(rd) = result;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+
+union clause ast = RISCV_JALR : (bits(12), regidx, regidx)
+
+function clause decode imm : bits(12) @ rs1 : regidx @ 0b000 @ rd :regidx @ 0b1100111
+  = RISCV_JALR(imm, rs1, rd)
+
+function clause execute (RISCV_JALR(imm, rs1, rd)) = {
+  let target : xlenbits = X(rs1) + sign_extend(imm);
+  /*
+   * For simplicity, we omit target address validation
+   * (memory unmapped or not executable and so on)
+   */
+  PC = target;
+  RETIRE_SUCCESS
+}
+
+/* ****************************************************************** */
+
+union clause ast = INVALID : (unit)
+
+function clause decode _ = INVALID(())
+
+// Otherwise Sail will complain about unmatched cases
+function clause execute _ = RETIRE_FAIL
+
+
+val decode_and_execute : bits(32) -> retire_status
+
+function decode_and_execute(enc) = {
+  execute(decode(enc));
+}


### PR DESCRIPTION
This commit adds RISC-V "quattropod", a toy Sail Model for RISC-V containing only branch R-type, I-type, B-type instructions and `jalr` instruction from RV64I base instruction set.